### PR TITLE
Add anonymous plugin engagement metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 node_modules/
 npm-debug.log*
+worker/.dev.vars*
+worker/.env*
+worker/.wrangler/
+worker/wrangler.jsonc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Preserve these product qualities:
 - Fast, static, accessible, and usable without an application server
 - Curated, while stating clearly that listing is not a security review
 
-Do not introduce accounts, a database, a backend, a frontend framework, or a new dependency unless the maintainer explicitly approves that architectural change.
+Do not introduce accounts, a database, a backend, a frontend framework, or a new dependency unless the maintainer explicitly approves that architectural change. The approved exception is the credential-free engagement feature under `worker/`: a narrowly scoped Cloudflare Worker and D1 database may store anonymous aggregate plugin detail views, successful command-copy actions, and hearts guarded by local browser storage. Hearts are anonymous reactions, not unique or verified votes. Do not expand it into identity, profiling, comments, scored ratings, installation telemetry, or general analytics without separate approval.
 
 ## Project structure and sources of truth
 
@@ -22,6 +22,7 @@ Do not introduce accounts, a database, a backend, a frontend framework, or a new
 - `site/publish.html` contains the publishing guide
 - `site/assets/css/style.css` is the shared visual system
 - `site/assets/js/shared.js` contains shared browser behavior
+- `site/assets/js/engagement.js` contains the credential-free engagement API client
 - `site/assets/js/app.js`, `plugin.js`, `publish.js`, and `search.js` contain page-specific behavior
 - `registry.json` is the curated registry and the source of marketplace metadata
 - Upstream plugin `manifest.json` files are the source of plugin-owned metadata
@@ -29,6 +30,7 @@ Do not introduce accounts, a database, a backend, a frontend framework, or a new
 - `site/catalog.json` and `site/assets/img/plugins/` are generated build outputs
 - `sharp` is the build-only image dependency; source previews are normalized into card and detail WebP variants
 - `SUBMISSION.md` defines the public command-line and AI-assisted submission contract
+- `worker/src/index.js`, `worker/migrations/`, and `worker/wrangler.example.jsonc` define the approved engagement service, D1 schema, and credential-free deployment template
 - `PLAN.md` records the original architecture and design rationale; current code, tests, and workflows take precedence when the plan is stale
 
 Do not manually edit generated catalog data or preview assets. Change their source or build logic, then regenerate them. Do not include unrelated catalog drift in a UI-only change.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Read the [security baseline guidelines](SECURITY_BASELINE.md) before submitting 
 
 An optional root preview is resized and optimized automatically.
 
+## Engagement Metrics
+
+The marketplace displays anonymous aggregate plugin detail views, successful command-copy actions, and hearts. A detail view is guarded once per plugin and browser session as a best-effort refresh limit. Copy activity is recorded only after the clipboard action succeeds. A heart is guarded once per plugin in local browser storage.
+
+These counters are marketplace interactions, not downloads, installations, unique people, verified votes, quality rankings, or security signals. Browser storage can be cleared or bypassed, so hearts remain anonymous reactions rather than unique votes. The application sends only the catalog plugin ID and the fixed action type to the Cloudflare Worker. It does not store accounts, cookies, IP addresses, user-agent strings, command text, or repository URLs in D1. Cloudflare uses the request IP only as an ephemeral edge rate-limit key and otherwise processes normal request metadata as the network provider under the account's Cloudflare configuration.
+
 ## Security Notice
 
 > Community plugins are developed and maintained by independent third parties. They execute as unsandboxed code and may access or modify files,

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -298,7 +298,7 @@ svg {
   background: var(--code-bg); flex: 0 0 auto; align-items: center; color: var(--text);
   font-family: var(--mono); font-size: 11px; font-weight: 500; letter-spacing: .02em; white-space: nowrap;
 }
-.status-badge, .new-badge, .updated-badge, .builtin-badge {
+.status-badge, .builtin-badge {
   padding: 3px 7px;
   color: #111;
   font-family: var(--mono);
@@ -309,10 +309,6 @@ svg {
   text-transform: uppercase;
 }
 .status-badge { border: 1px solid var(--accent); background: var(--accent); color: var(--accent-contrast); }
-.new-badge { border: 1px solid var(--stable); background: var(--stable); }
-.updated-badge { border: 1px solid var(--updated); background: var(--updated); }
-[data-theme="light"] .new-badge { border-color: #b4c96f; background: #b4c96f; }
-[data-theme="light"] .updated-badge { border-color: #ffb000; background: #ffb000; }
 .builtin-badge { border: 1px solid var(--blue, #74a7f7); background: var(--blue, #74a7f7); }
 .plugin-side { position: relative; z-index: 3; display: flex; align-items: flex-end; flex-direction: column; gap: 12px; }
 .plugin-stats { display: grid; width: 100%; grid-template-columns: 1fr 1fr; color: var(--faint); font-family: var(--mono); font-size: 11px; }
@@ -857,33 +853,105 @@ svg {
   flex: 1; flex-direction: column;
 }
 .plugin-card-content { min-width: 0; }
-.plugin-title-line { padding-right: 48px; }
+.plugin-title-line { padding-right: 120px; }
 .plugin-title-line { flex-wrap: wrap; }
 .plugin-title-line h3 { font-family: var(--mono); font-size: 15px; }
 .plugin-title-line .status-badge { margin-left: 4px; }
 .plugin-title-line .builtin-badge { margin-left: 4px; }
-.built-in-card .plugin-title-line { padding-right: 0; }
+.built-in-card .plugin-title-line { padding-right: 62px; }
+.card-social {
+  position: absolute; z-index: 3; top: 13px; right: 12px; display: flex; height: 25px;
+  align-items: center; gap: 4px;
+}
 .card-stars {
-  position: absolute; top: 13px; right: 12px; display: inline-flex; padding: 2px 6px;
-  background: #323236; align-items: center; gap: 4px; color: #fff; font-family: var(--mono); font-size: 11px;
+  display: inline-flex; width: 54px; min-width: 54px; height: 25px; padding: 0 4px;
+  border: 1px solid var(--line-strong); background: var(--code-bg);
+  align-items: center; justify-content: center; gap: 6px; color: var(--text);
+  font-family: var(--mono); font-size: 11px; line-height: 1;
 }
-.card-stars svg { width: 10px; fill: currentColor; }
+.plugin-heart {
+  position: relative; display: inline-flex; width: 54px; min-width: 54px; height: 25px; padding: 0 4px;
+  border: 1px solid var(--line-strong); background: var(--code-bg);
+  align-items: center; justify-content: center; gap: 6px; color: var(--text);
+  font-family: var(--mono); font-size: 11px; font-weight: 650;
+  font-variant-numeric: tabular-nums; line-height: 1; cursor: pointer;
+}
+.social-glyph {
+  display: inline-grid; width: 13px; height: 13px; color: var(--accent); font-family: var(--mono);
+  font-size: 14px; font-weight: 500; line-height: 1; place-items: center;
+  transform: translateY(-1px);
+}
+.star-glyph { color: var(--updated); }
+.social-count { display: inline-flex; align-items: center; justify-content: center; line-height: 11px; }
+.plugin-heart:hover:not([aria-disabled="true"]), .plugin-heart:focus-visible { background: var(--panel); }
+.plugin-heart.is-hearted { background: color-mix(in srgb, var(--accent) 10%, var(--code-bg)); }
+.plugin-heart[aria-disabled="true"] { opacity: 1; cursor: default; }
+.plugin-heart.is-pending [data-heart-value] { visibility: hidden; }
+.plugin-heart.is-celebrating .heart-glyph {
+  animation: heart-confirm 220ms cubic-bezier(.2, .85, .25, 1);
+}
+.plugin-engagement {
+  display: flex; min-height: 20px; align-items: center; gap: 13px; color: var(--muted);
+  font-family: var(--mono); font-size: 10px; font-weight: 650; font-variant-numeric: tabular-nums;
+  letter-spacing: .035em; text-transform: uppercase;
+}
+.plugin-engagement.is-pending { visibility: hidden; }
+.engagement-metric, .engagement-visual { display: inline-flex; align-items: center; white-space: nowrap; }
+.engagement-visual { gap: 5px; }
+.engagement-glyph {
+  display: inline-grid; width: 13px; height: 13px; color: var(--faint); font-family: var(--mono);
+  font-size: 14px; font-weight: 500; line-height: 1; place-items: center;
+}
+.engagement-copy-icon { width: 13px; height: 13px; color: var(--faint); }
+.detail-engagement-cluster {
+  display: flex; margin-top: 14px; align-items: center; flex-wrap: wrap; gap: 14px;
+}
+.detail-engagement { margin-top: 0; gap: 17px; }
+.detail-heart { height: 25px; border-color: var(--line); background: var(--panel); }
+.detail-engagement .engagement-visual { gap: 6px; }
+.detail-engagement .engagement-name { color: var(--faint); font-size: 9px; letter-spacing: .08em; }
 .plugin-card-body .plugin-description {
-  display: -webkit-box; min-height: 42px; max-height: 42px; margin: 12px 0; overflow: hidden;
-  color: var(--muted); font-size: 13px; line-height: 1.6; -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2; line-clamp: 2;
+  display: block; min-height: 21px; max-height: 21px; margin: 4px 0 9px; overflow: hidden;
+  color: var(--muted); font-size: 13px; line-height: 1.6; text-overflow: clip; white-space: nowrap;
+  -webkit-mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 28px), transparent 100%);
+  mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 28px), transparent 100%);
 }
+.card-activity-state {
+  display: flex; width: max-content; height: 21px; margin: auto 0 5px; padding: 0 7px;
+  border: 0; border-left: 2px solid currentColor; background: var(--code-bg);
+  align-items: center; color: var(--stable); font-family: var(--mono); font-size: 10px;
+  font-weight: 700; letter-spacing: .04em; line-height: 11px; text-transform: uppercase;
+  white-space: nowrap;
+}
+.card-activity-state.is-updated { color: var(--updated); }
 .plugin-author button {
   position: relative; z-index: 3; display: inline-flex; min-height: 24px;
   padding: 0 4px; margin: -3px -4px; border: 0; background: transparent;
   align-items: center; color: inherit; font: inherit; cursor: pointer;
 }
 .plugin-author button:hover, .plugin-author button:focus-visible { color: var(--accent); }
-.plugin-card-bottom { display: flex; margin-top: auto; align-items: end; justify-content: space-between; gap: 10px; }
-.plugin-card-bottom .plugin-tags { height: 28px; overflow: hidden; flex-wrap: nowrap; }
+.plugin-card-bottom { display: flex; margin-top: auto; align-items: center; justify-content: space-between; gap: 10px; }
+.card-activity-state + .plugin-card-bottom { margin-top: 0; }
+.plugin-card-bottom .plugin-tags { min-width: 0; height: 28px; overflow: hidden; flex-wrap: nowrap; }
+.plugin-card-bottom .tag { padding: 0 8px; text-transform: lowercase; }
+.plugin-card-actions {
+  position: relative; z-index: 3; display: flex; min-height: 25px; flex: none;
+  align-items: center; gap: 4px;
+}
+.plugin-card-actions .plugin-engagement { min-height: 25px; gap: 4px; }
+.plugin-card-actions .engagement-metric {
+  height: 25px; padding: 0 6px; border: 1px solid var(--line); background: transparent;
+}
+.plugin-card-actions .engagement-visual { gap: 4px; }
+.plugin-card-actions [data-engagement-metric="views"] .engagement-visual { gap: 6px; }
+.plugin-card-actions .engagement-glyph,
+.plugin-card-actions .engagement-copy-icon,
+.plugin-card-actions .card-install .command-glyph,
+.plugin-card-actions .card-install .copy-icon { color: var(--accent); }
+.plugin-card-actions .engagement-copy-icon::after,
+.plugin-card-actions .card-install .copy-icon::after { background: var(--panel); }
 .plugin-card-bottom .card-install { position: relative; z-index: 3; flex: none; min-height: 25px; padding: 0 7px; }
 .plugin-card-bottom .card-install [data-copy-label] { display: none; }
-.plugin-card-bottom .card-install .command-glyph { color: var(--accent); }
 .plugin-card-bottom .builtin-source-action { color: var(--text); white-space: nowrap; }
 .catalog-pagination {
   display: grid; margin-top: 36px; border: 1px solid var(--line);
@@ -1082,6 +1150,11 @@ svg {
   }
   .footer-maintainer { grid-column: 1; grid-row: 2; }
   .footer-resource-links { grid-column: 2; grid-row: 2; gap: 13px; }
+}
+@keyframes heart-confirm {
+  0% { transform: translateY(-1px) scale(.82); }
+  55% { transform: translateY(-1px) scale(1.12); }
+  100% { transform: translateY(-1px) scale(1); }
 }
 @media (max-width: 700px) {
   .search-query-summary, .search-suggestion { min-height: 44px; }

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -4,18 +4,30 @@ import {
   appendCatalogViewState,
   catalogViewControls,
   copyText,
+  engagementSummary,
   escapeHtml,
   formatStars,
+  hidePendingEngagement,
   isRecentlyAdded,
   isRecentlyUpdated,
   listingTime,
   loadCatalog,
   paginationState,
+  pluginHeartButton,
   readCatalogViewState,
   setupCopyButtons,
   setupThemeToggle,
-  starIcon
-} from "./shared.js?v=20260808-52";
+  showToast,
+  updateEngagementSummary,
+  updatePluginHeart
+} from "./shared.js?v=20260816-04";
+import {
+  engagementApiBaseUrl,
+  hasPluginHeart,
+  loadEngagementStats,
+  recordEngagementEvent,
+  recordPluginHeart,
+} from "./engagement.js?v=20260816-04";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -38,9 +50,44 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260808-52";
+} from "./search.js?v=20260816-04";
 
 const pluginsPerPage = 9;
+const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
+const cardCategoryNames = new Map([
+  ["Developer Tools", "Dev"],
+  ["Productivity", "Product."],
+]);
+const cardTagNames = new Map([
+  ["power-management", "system"],
+  ["workspaces", "Workspace"],
+]);
+
+function taxonomyKey(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/s$/, "");
+}
+
+function cardTaxonomyLabels(plugin) {
+  const category = String(plugin.category || "").trim();
+  const categoryKey = taxonomyKey(category);
+  const specific = [];
+
+  for (const tag of plugin.tags || []) {
+    if (hiddenCardTags.has(tag)) continue;
+    const label = cardTagNames.get(tag) || tag;
+    const labelKey = taxonomyKey(label);
+    if (labelKey === categoryKey || specific.some((value) => taxonomyKey(value) === labelKey)) continue;
+    specific.push(label);
+  }
+
+  if (category === "Widgets" && specific.length) return specific.slice(0, 1);
+  if (category === "Productivity") return [cardCategoryNames.get(category)];
+  return [cardCategoryNames.get(category) || category, ...specific].filter(Boolean).slice(0, 2);
+}
 
 const sortOptions = {
   community: [
@@ -63,7 +110,11 @@ const state = {
   category: "all",
   sort: "added",
   page: 1,
-  showAll: false
+  showAll: false,
+  engagement: {},
+  engagementAuthoritative: {},
+  engagementEnabled: false,
+  engagementLoaded: false
 };
 
 const grid = document.querySelector("#plugin-grid");
@@ -475,17 +526,73 @@ function filteredPlugins() {
   return result.sort(sorters[state.sort] || sorters[sourceDefaultSort()]);
 }
 
+function pluginEngagement(plugin) {
+  if (!state.engagementEnabled) return "";
+  return engagementSummary(plugin, state.engagement[plugin.id], {
+    pending: !state.engagementLoaded,
+  });
+}
+
+function applyAuthoritativeEngagement(pluginId, result) {
+  if (!result?.recorded || !result.stats) return;
+  const current = state.engagementAuthoritative[pluginId]
+    || state.engagement[pluginId]
+    || { views: 0, copies: 0, hearts: 0 };
+  const next = {
+    views: Math.max(current.views, result.stats.views),
+    copies: Math.max(current.copies, result.stats.copies),
+    hearts: Math.max(current.hearts, result.stats.hearts),
+  };
+  state.engagementAuthoritative[pluginId] = next;
+  state.engagement[pluginId] = next;
+  updateEngagementSummary(document, pluginId, next);
+  updatePluginHeart(document, pluginId, next, {
+    hearted: hasPluginHeart(pluginId),
+  });
+}
+
+async function heartPlugin(button) {
+  if (button.getAttribute("aria-disabled") === "true" || button.dataset.heartSubmitting === "true") return;
+  button.dataset.heartSubmitting = "true";
+  button.setAttribute("aria-busy", "true");
+  const pluginId = button.dataset.pluginHeart;
+  const result = await recordPluginHeart(pluginId);
+  delete button.dataset.heartSubmitting;
+  button.removeAttribute("aria-busy");
+  if (!result?.recorded) {
+    showToast("Heart could not be sent. Try again.");
+    return;
+  }
+  applyAuthoritativeEngagement(pluginId, result);
+  updatePluginHeart(document, pluginId, result.stats, {
+    animate: true,
+    hearted: true,
+  });
+  showToast("Heart sent.");
+}
+
+async function copyPluginCommand(button) {
+  if (!await copyText(button.dataset.copyCommand, button)) return;
+  const pluginId = button.dataset.pluginId;
+  applyAuthoritativeEngagement(
+    pluginId,
+    await recordEngagementEvent(pluginId, "copy"),
+  );
+}
+
 function pluginCard(plugin, { showNew = false } = {}) {
-  const tags = (plugin.tags || []).slice(0, 2).map((tag) => `<span class="tag">${escapeHtml(tag)}</span>`).join("");
+  const tags = cardTaxonomyLabels(plugin)
+    .map((label) => `<span class="tag">${escapeHtml(label)}</span>`)
+    .join("");
   const badge = plugin.builtIn
     ? '<span class="builtin-badge">Built-in</span>'
     : plugin.placeholder
       ? '<span class="status-badge">Coming soon</span>'
       : "";
-  const activityBadge = showNew && isRecentlyUpdated(plugin)
-    ? '<span class="updated-badge">Updated</span>'
+  const activityState = showNew && isRecentlyUpdated(plugin)
+    ? '<span class="card-activity-state is-updated">Updated</span>'
     : showNew && isRecentlyAdded(plugin)
-      ? '<span class="new-badge">New</span>'
+      ? '<span class="card-activity-state is-new">New</span>'
       : "";
   const installAction = plugin.builtIn
     ? `<a class="card-install builtin-source-action" href="${escapeHtml(plugin.sourceUrl || plugin.repo)}" target="_blank" rel="noreferrer" aria-label="View source for ${escapeHtml(plugin.name)}">View source ↗</a>`
@@ -493,7 +600,7 @@ function pluginCard(plugin, { showNew = false } = {}) {
       ? '<span class="card-install unavailable" aria-label="Installation not yet available"><span class="command-glyph" aria-hidden="true"></span> Preview only</span>'
       : !plugin.installAvailable
         ? `<span class="card-install unavailable" aria-label="Automatic installation unavailable"><span class="command-glyph" aria-hidden="true"></span> ${plugin.upstreamCheckStatus === "failed" ? "Unavailable" : "Manual setup"}</span>`
-        : `<button class="card-install" type="button" data-copy-command="${escapeHtml(plugin.installCommand)}" aria-label="Copy install command for ${escapeHtml(plugin.name)}">
+        : `<button class="card-install" type="button" data-copy-command="${escapeHtml(plugin.installCommand)}" data-plugin-id="${escapeHtml(plugin.id)}" aria-label="Copy install command for ${escapeHtml(plugin.name)}">
           <span class="command-glyph" aria-hidden="true"></span><span data-copy-label>Copy install</span>
           <span class="copy-icon" aria-hidden="true"></span>
         </button>`;
@@ -503,7 +610,14 @@ function pluginCard(plugin, { showNew = false } = {}) {
     : `<div class="plugin-preview" aria-hidden="true">
         <span class="plugin-preview-mark">${escapeHtml(plugin.initials)}</span>
       </div>`;
-  const stars = plugin.builtIn ? "" : `<span class="card-stars" title="Repository stars">${starIcon()} ${formatStars(plugin.stars)}</span>`;
+  const stars = plugin.builtIn ? "" : `<span class="card-stars" title="Repository stars" aria-label="${formatStars(plugin.stars)} repository stars"><span class="social-glyph star-glyph" aria-hidden="true"></span><span class="social-count" aria-hidden="true">${formatStars(plugin.stars)}</span></span>`;
+  const heart = state.engagementEnabled
+    ? pluginHeartButton(plugin, state.engagement[plugin.id], {
+        hearted: hasPluginHeart(plugin.id),
+        pending: !state.engagementLoaded,
+      })
+    : "";
+  const social = stars || heart ? `<div class="card-social">${stars}${heart}</div>` : "";
   const publisher = publisherLogin(plugin);
   const authorLine = publisher && !plugin.builtIn
     ? `<span class="plugin-author">by <button type="button" data-author="${escapeHtml(publisher)}" aria-label="Show all plugins by @${escapeHtml(publisher)}">@${escapeHtml(publisher)}</button> · ${escapeHtml(plugin.kind || plugin.category)}</span>`
@@ -518,23 +632,29 @@ function pluginCard(plugin, { showNew = false } = {}) {
           <div class="plugin-title-line">
             <h3>${escapeHtml(plugin.name)}</h3>
             ${badge}
-            ${activityBadge}
-            ${stars}
+            ${social}
           </div>
           ${authorLine}
           <p class="plugin-description">${escapeHtml(plugin.description)}</p>
         </div>
+        ${activityState}
         <div class="plugin-card-bottom">
           <div class="plugin-tags">${tags}</div>
-          ${installAction}
+          <div class="plugin-card-actions">
+            ${pluginEngagement(plugin)}
+            ${installAction}
+          </div>
         </div>
       </div>
     </article>`;
 }
 
 function bindCardActions(root) {
+  root.querySelectorAll("[data-plugin-heart]").forEach((button) => {
+    button.addEventListener("click", () => heartPlugin(button));
+  });
   root.querySelectorAll("[data-copy-command]").forEach((button) => {
-    button.addEventListener("click", () => copyText(button.dataset.copyCommand, button));
+    button.addEventListener("click", () => copyPluginCommand(button));
   });
   root.querySelectorAll("[data-author]").forEach((button) => {
     button.addEventListener("click", () => {
@@ -1014,6 +1134,7 @@ async function init() {
       throw new Error("Catalog response is invalid");
     }
     state.plugins = catalog.plugins;
+    state.engagementEnabled = Boolean(engagementApiBaseUrl());
     restoreUrl();
     renderSearchTerms();
     renderRecentlyAdded();
@@ -1021,6 +1142,24 @@ async function init() {
     renderSortOptions();
     renderCategories();
     render();
+    if (state.engagementEnabled) {
+      loadEngagementStats().then((stats) => {
+        state.engagement = { ...stats, ...state.engagementAuthoritative };
+        state.engagementLoaded = true;
+        document.querySelectorAll("[data-plugin-engagement]").forEach((summary) => {
+          const pluginId = summary.dataset.pluginEngagement;
+          const pluginStats = state.engagement[pluginId] || { views: 0, copies: 0, hearts: 0 };
+          updateEngagementSummary(document, pluginId, pluginStats);
+          updatePluginHeart(document, pluginId, pluginStats, {
+            hearted: hasPluginHeart(pluginId),
+          });
+        });
+      }).catch((reason) => {
+        console.warn("Engagement stats unavailable", reason);
+        state.engagementEnabled = false;
+        hidePendingEngagement(document);
+      });
+    }
   } catch (error) {
     console.error(error);
     grid.hidden = true;

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260808-52";
+} from "./shared.js?v=20260816-04";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/engagement.js
+++ b/site/assets/js/engagement.js
@@ -1,0 +1,162 @@
+const productionSiteHosts = new Set([
+  "omarchyplugins.com",
+  "www.omarchyplugins.com",
+]);
+const localSiteHosts = new Set(["127.0.0.1", "localhost"]);
+const eventTypes = new Set(["view", "copy", "heart"]);
+const pluginIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const unsafeObjectKeys = new Set(["__proto__", "constructor", "prototype"]);
+const viewStoragePrefix = "omarchy-plugin-view:";
+const heartStoragePrefix = "omarchy-plugin-heart:";
+const heartRequests = new Map();
+
+function validPluginId(value) {
+  return pluginIdPattern.test(value) && !unsafeObjectKeys.has(value.toLowerCase());
+}
+
+export function engagementApiBaseUrl(locationRef = globalThis.location) {
+  const hostname = String(locationRef?.hostname || "").toLowerCase();
+  if (localSiteHosts.has(hostname)) return "http://127.0.0.1:8787/v1";
+  if (productionSiteHosts.has(hostname)) return "https://api.omarchyplugins.com/v1";
+  return "";
+}
+
+function safeCount(value) {
+  const count = Math.trunc(Number(value));
+  return Number.isSafeInteger(count) && count >= 0 ? count : 0;
+}
+
+export function normalizeEngagementStats(payload) {
+  const source = payload?.plugins;
+  if (!source || typeof source !== "object" || Array.isArray(source)) return {};
+  const normalized = {};
+  for (const [pluginId, value] of Object.entries(source)) {
+    if (!validPluginId(pluginId) || !value || typeof value !== "object") continue;
+    normalized[pluginId] = {
+      views: safeCount(value.views),
+      copies: safeCount(value.copies),
+      hearts: safeCount(value.hearts),
+    };
+  }
+  return normalized;
+}
+
+export async function loadEngagementStats({
+  fetchImpl = globalThis.fetch,
+  locationRef = globalThis.location,
+} = {}) {
+  const baseUrl = engagementApiBaseUrl(locationRef);
+  if (!baseUrl || typeof fetchImpl !== "function") return {};
+  const response = await fetchImpl(`${baseUrl}/stats`, {
+    cache: "no-store",
+    credentials: "omit",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) throw new Error(`Engagement request failed: ${response.status}`);
+  return normalizeEngagementStats(await response.json());
+}
+
+function normalizedPluginStats(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return {
+    views: safeCount(value.views),
+    copies: safeCount(value.copies),
+    hearts: safeCount(value.hearts),
+  };
+}
+
+export async function recordEngagementEvent(pluginId, type, {
+  fetchImpl = globalThis.fetch,
+  locationRef = globalThis.location,
+} = {}) {
+  const baseUrl = engagementApiBaseUrl(locationRef);
+  if (
+    !baseUrl
+    || typeof fetchImpl !== "function"
+    || !validPluginId(String(pluginId || ""))
+    || !eventTypes.has(type)
+  ) return null;
+
+  try {
+    const response = await fetchImpl(`${baseUrl}/events`, {
+      method: "POST",
+      credentials: "omit",
+      keepalive: true,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ pluginId, type }),
+    });
+    if (!response.ok) return null;
+    const payload = await response.json();
+    if (payload?.recorded === false) return { recorded: false, stats: null };
+    const stats = normalizedPluginStats(payload?.plugin);
+    return payload?.recorded === true && stats
+      ? { recorded: true, stats }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasPluginHeart(pluginId, storage = globalThis.localStorage) {
+  if (!validPluginId(String(pluginId || ""))) return false;
+  try {
+    return storage?.getItem(`${heartStoragePrefix}${pluginId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export async function recordPluginHeart(pluginId, {
+  storage = globalThis.localStorage,
+  ...options
+} = {}) {
+  const baseUrl = engagementApiBaseUrl(options.locationRef || globalThis.location);
+  if (!baseUrl || !validPluginId(String(pluginId || ""))) return null;
+  if (hasPluginHeart(pluginId, storage)) return { recorded: false, stats: null };
+  if (heartRequests.has(pluginId)) return heartRequests.get(pluginId);
+
+  const request = (async () => {
+    const result = await recordEngagementEvent(pluginId, "heart", options);
+    if (!result?.recorded) return result;
+    try {
+      storage?.setItem(`${heartStoragePrefix}${pluginId}`, "1");
+    } catch {
+      // The reaction is still recorded when browser storage is unavailable.
+    }
+    return result;
+  })();
+  heartRequests.set(pluginId, request);
+  try {
+    return await request;
+  } finally {
+    if (heartRequests.get(pluginId) === request) heartRequests.delete(pluginId);
+  }
+}
+
+export async function recordPluginView(pluginId, {
+  storage = globalThis.sessionStorage,
+  ...options
+} = {}) {
+  const baseUrl = engagementApiBaseUrl(options.locationRef || globalThis.location);
+  if (!baseUrl || !validPluginId(String(pluginId || ""))) return null;
+  const key = `${viewStoragePrefix}${pluginId}`;
+  try {
+    if (storage?.getItem(key)) return { recorded: false, stats: null };
+    storage?.setItem(key, "1");
+  } catch {
+    // Storage is only a best-effort refresh guard. The event remains anonymous.
+  }
+
+  const result = await recordEngagementEvent(pluginId, "view", options);
+  if (result === null) {
+    try {
+      storage?.removeItem(key);
+    } catch {
+      // A later page load may still retry when storage is unavailable.
+    }
+  }
+  return result;
+}

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -2,16 +2,29 @@ import {
   accentColor,
   copyText,
   currentHashId,
+  engagementSummary,
   escapeHtml,
   formatDate,
   formatStars,
+  hidePendingEngagement,
   listingCheckState,
   loadCatalog,
+  pluginHeartButton,
   pluginVersionLabel,
   setupSectionNavigation,
   setupThemeToggle,
-  starIcon
-} from "./shared.js?v=20260808-52";
+  showToast,
+  updateEngagementSummary,
+  updatePluginHeart
+} from "./shared.js?v=20260816-04";
+import {
+  engagementApiBaseUrl,
+  hasPluginHeart,
+  loadEngagementStats,
+  recordEngagementEvent,
+  recordPluginHeart,
+  recordPluginView,
+} from "./engagement.js?v=20260816-04";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";
@@ -22,7 +35,11 @@ function statusTone(plugin) {
   return "";
 }
 
-function detailTemplate(plugin) {
+function detailTemplate(plugin, engagement, {
+  engagementEnabled = false,
+  hearted = false,
+  pendingEngagement = false,
+} = {}) {
   const securityReportUrl = "https://github.com/HANCORE-linux/omarchy-plugin-marketplace/security/advisories/new";
   const tags = (plugin.tags || []).map((tag) => `<span class="tag">${escapeHtml(tag)}</span>`).join("");
   const preview = plugin.previewImage
@@ -114,6 +131,10 @@ function detailTemplate(plugin) {
       <header class="page-header" id="overview"><div class="page-eyebrow">${escapeHtml(plugin.category)}</div>
         <div class="detail-title"><span class="detail-icon">${escapeHtml(plugin.initials)}</span><h1>${escapeHtml(plugin.name)}</h1></div>
         <div class="page-meta"><span>${escapeHtml(plugin.id)}</span>${manifestVersion}<span>by ${escapeHtml(plugin.author)}</span><span class="status ${statusTone(plugin)}"><i class="status-dot" aria-hidden="true"></i>${escapeHtml(plugin.status || "Available")}</span></div>
+        ${engagementEnabled ? `<div class="detail-engagement-cluster">
+          ${engagementSummary(plugin, engagement, { detail: true, pending: pendingEngagement })}
+          ${pluginHeartButton(plugin, engagement, { detail: true, hearted, pending: pendingEngagement })}
+        </div>` : ""}
       </header>
       <p class="detail-description">${escapeHtml(plugin.description)}</p>${preview}<div class="plugin-tags">${tags}</div>
       <section class="detail-section" id="install"><h2>${plugin.builtIn ? escapeHtml(plugin.officialCommandLabel) : availabilityHeading}</h2>${install}</section>
@@ -136,6 +157,10 @@ async function init() {
   setupThemeToggle();
   const id = new URLSearchParams(location.search).get("id");
   const content = document.querySelector("#detail-content");
+  const engagementEnabled = Boolean(engagementApiBaseUrl());
+  let pluginEngagement = { views: 0, copies: 0, hearts: 0 };
+  let authoritativeEngagement = null;
+  let engagementLoaded = false;
   let catalog;
   try {
     catalog = await loadCatalog();
@@ -172,7 +197,11 @@ async function init() {
     document.title = `${plugin.name} | Omarchy Plugins`;
     document.querySelector("#crumb-name").textContent = plugin.name;
     content.className = "";
-    content.innerHTML = detailTemplate(plugin);
+    content.innerHTML = detailTemplate(plugin, pluginEngagement, {
+      engagementEnabled,
+      hearted: hasPluginHeart(plugin.id),
+      pendingEngagement: engagementEnabled,
+    });
     if (currentHashId() === "trust") {
       const url = new URL(location.href);
       url.hash = "terms";
@@ -223,8 +252,69 @@ async function init() {
           : "Status";
     }
 
+    const applyAuthoritativeEngagement = (result) => {
+      if (!result?.recorded || !result.stats) return;
+      authoritativeEngagement = {
+        views: Math.max(authoritativeEngagement?.views || 0, result.stats.views),
+        copies: Math.max(authoritativeEngagement?.copies || 0, result.stats.copies),
+        hearts: Math.max(authoritativeEngagement?.hearts || 0, result.stats.hearts),
+      };
+      pluginEngagement = authoritativeEngagement;
+      engagementLoaded = true;
+      const engagementCluster = content.querySelector(".detail-engagement-cluster");
+      if (engagementCluster) engagementCluster.hidden = false;
+      updateEngagementSummary(document, plugin.id, pluginEngagement);
+      updatePluginHeart(document, plugin.id, pluginEngagement, {
+        hearted: hasPluginHeart(plugin.id),
+      });
+    };
+
+    const heartButton = content.querySelector("[data-plugin-heart]");
+    heartButton?.addEventListener("click", async () => {
+      if (heartButton.getAttribute("aria-disabled") === "true" || heartButton.dataset.heartSubmitting === "true") return;
+      heartButton.dataset.heartSubmitting = "true";
+      heartButton.setAttribute("aria-busy", "true");
+      const result = await recordPluginHeart(plugin.id);
+      delete heartButton.dataset.heartSubmitting;
+      heartButton.removeAttribute("aria-busy");
+      if (!result?.recorded) {
+        showToast("Heart could not be sent. Try again.");
+        return;
+      }
+      applyAuthoritativeEngagement(result);
+      updatePluginHeart(document, plugin.id, result.stats, {
+        animate: true,
+        hearted: true,
+      });
+      showToast("Heart sent.");
+    });
+
     const copyButton = content.querySelector("[data-install-copy]");
-    copyButton?.addEventListener("click", () => copyText(plugin.builtIn ? plugin.officialCommand : plugin.installCommand, copyButton));
+    copyButton?.addEventListener("click", async () => {
+      const command = plugin.builtIn ? plugin.officialCommand : plugin.installCommand;
+      if (!await copyText(command, copyButton)) return;
+      applyAuthoritativeEngagement(await recordEngagementEvent(plugin.id, "copy"));
+    });
+
+    if (engagementEnabled) {
+      loadEngagementStats().then((stats) => {
+        const current = stats[plugin.id] || { views: 0, copies: 0, hearts: 0 };
+        pluginEngagement = authoritativeEngagement || current;
+        engagementLoaded = true;
+        updateEngagementSummary(document, plugin.id, pluginEngagement);
+        updatePluginHeart(document, plugin.id, pluginEngagement, {
+          hearted: hasPluginHeart(plugin.id),
+        });
+      }).catch((reason) => {
+        console.warn("Engagement stats unavailable", reason);
+        if (!engagementLoaded) {
+          hidePendingEngagement(document);
+          const engagementCluster = content.querySelector(".detail-engagement-cluster");
+          if (engagementCluster) engagementCluster.hidden = true;
+        }
+      });
+      recordPluginView(plugin.id).then(applyAuthoritativeEngagement);
+    }
   } catch (reason) {
     console.error(reason);
     showDetailError({

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260808-52";
+} from "./shared.js?v=20260816-04";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -29,8 +29,113 @@ export function formatDate(value) {
 }
 
 export function formatStars(value = 0) {
-  if (value < 1000) return String(value);
-  return `${(value / 1000).toFixed(1)}k`;
+  return formatEngagementCount(value);
+}
+
+function engagementCount(value) {
+  const count = Math.trunc(Number(value));
+  return Number.isSafeInteger(count) && count >= 0 ? count : 0;
+}
+
+export function formatEngagementCount(value = 0) {
+  const count = engagementCount(value);
+  if (count < 1000) return String(count);
+  if (count < 10_000) return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
+  return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
+}
+
+function engagementMetric(type, count, detail) {
+  const views = type === "views";
+  const label = views ? "marketplace detail views" : "successful command copies";
+  const icon = views
+    ? '<span class="engagement-glyph" aria-hidden="true"></span>'
+    : '<span class="copy-icon engagement-copy-icon" aria-hidden="true"></span>';
+  const visibleName = views ? "views" : "copies";
+  return `<span class="engagement-metric" data-engagement-metric="${type}" title="${label}"><span class="engagement-visual" aria-hidden="true">${icon}<span data-engagement-value>${formatEngagementCount(count)}</span>${detail ? `<span class="engagement-name">${visibleName}</span>` : ""}</span><span class="sr-only" data-engagement-accessible>${count} ${label}</span></span>`;
+}
+
+export function engagementSummary(plugin, stats = {}, {
+  detail = false,
+  pending = false,
+} = {}) {
+  const views = engagementCount(stats.views);
+  const copies = engagementCount(stats.copies);
+  const hasCommand = Boolean(plugin?.builtIn ? plugin.officialCommand : plugin?.installCommand);
+  return `<div class="plugin-engagement${detail ? " detail-engagement" : ""}${pending ? " is-pending" : ""}" data-plugin-engagement="${escapeHtml(plugin?.id || "")}"${pending ? ' aria-busy="true"' : ""}>${engagementMetric("views", views, detail)}${hasCommand ? engagementMetric("copies", copies, detail) : ""}</div>`;
+}
+
+export function pluginHeartButton(plugin, stats = {}, {
+  detail = false,
+  hearted = false,
+  pending = false,
+} = {}) {
+  const pluginId = escapeHtml(plugin?.id || "");
+  const pluginName = escapeHtml(plugin?.name || "plugin");
+  const count = engagementCount(stats.hearts);
+  const action = hearted ? "Heart sent" : "Send a heart";
+  return `<button class="plugin-heart${detail ? " detail-heart" : ""}${hearted ? " is-hearted" : ""}${pending ? " is-pending" : ""}" type="button" data-plugin-heart="${pluginId}" data-plugin-name="${pluginName}" aria-label="${action} for ${pluginName}; ${count} anonymous hearts" aria-pressed="${hearted}"${pending ? ' aria-busy="true"' : ""}${hearted ? ' aria-disabled="true"' : ""}><span class="social-glyph heart-glyph" data-heart-glyph aria-hidden="true"></span><span class="social-count" data-heart-value aria-hidden="true">${formatEngagementCount(count)}</span></button>`;
+}
+
+export function hidePendingEngagement(root) {
+  root.querySelectorAll(".plugin-engagement.is-pending, .plugin-heart.is-pending").forEach((element) => {
+    element.hidden = true;
+    element.classList.remove("is-pending");
+    element.removeAttribute("aria-busy");
+  });
+}
+
+export function updatePluginHeart(root, pluginId, stats = {}, {
+  animate = false,
+  hearted = false,
+} = {}) {
+  const count = engagementCount(stats.hearts);
+  root.querySelectorAll("[data-plugin-heart]").forEach((button) => {
+    if (button.dataset.pluginHeart !== pluginId) return;
+    button.hidden = false;
+    button.classList.remove("is-pending");
+    button.classList.toggle("is-hearted", hearted);
+    button.removeAttribute("aria-busy");
+    button.setAttribute("aria-pressed", String(hearted));
+    button.disabled = false;
+    if (hearted) button.setAttribute("aria-disabled", "true");
+    else button.removeAttribute("aria-disabled");
+    button.setAttribute("aria-label", `${hearted ? "Heart sent" : "Send a heart"} for ${button.dataset.pluginName || "plugin"}; ${count} anonymous hearts`);
+    const glyph = button.querySelector("[data-heart-glyph]");
+    if (glyph) glyph.textContent = "";
+    const value = button.querySelector("[data-heart-value]");
+    if (value) value.textContent = formatEngagementCount(count);
+    if (!animate) return;
+    button.classList.remove("is-celebrating");
+    void button.offsetWidth;
+    button.classList.add("is-celebrating");
+    button.addEventListener("animationend", () => {
+      button.classList.remove("is-celebrating");
+    }, { once: true });
+  });
+}
+
+export function updateEngagementSummary(root, pluginId, stats = {}) {
+  const values = {
+    views: engagementCount(stats.views),
+    copies: engagementCount(stats.copies),
+  };
+  root.querySelectorAll("[data-plugin-engagement]").forEach((summary) => {
+    if (summary.dataset.pluginEngagement !== pluginId) return;
+    summary.hidden = false;
+    summary.classList.remove("is-pending");
+    summary.removeAttribute("aria-busy");
+    summary.querySelectorAll("[data-engagement-metric]").forEach((metric) => {
+      const type = metric.dataset.engagementMetric;
+      if (!Object.hasOwn(values, type)) return;
+      const count = values[type];
+      const label = type === "views" ? "marketplace detail views" : "successful command copies";
+      const value = metric.querySelector("[data-engagement-value]");
+      if (value) value.textContent = formatEngagementCount(count);
+      const accessible = metric.querySelector("[data-engagement-accessible]");
+      if (accessible) accessible.textContent = `${count} ${label}`;
+    });
+  });
 }
 
 export function listingTime(plugin) {

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260808-60">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260808-52"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-04"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260808-60">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -180,6 +180,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260808-52"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-04"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260808-60">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260808-52"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-04"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260808-60">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260808-52"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-04"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -537,6 +537,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
     publish: await readFile(new URL("site/publish.html", root), "utf8"),
     develop: await readFile(new URL("site/develop.html", root), "utf8"),
     app: await readFile(new URL("site/assets/js/app.js", root), "utf8"),
+    engagementJs: await readFile(new URL("site/assets/js/engagement.js", root), "utf8"),
+    sharedJs: await readFile(new URL("site/assets/js/shared.js", root), "utf8"),
     searchJs: await readFile(new URL("site/assets/js/search.js", root), "utf8"),
     pluginJs: await readFile(new URL("site/assets/js/plugin.js", root), "utf8"),
     publishJs: await readFile(new URL("site/assets/js/publish.js", root), "utf8"),
@@ -554,8 +556,10 @@ test("entry modules and their shared dependency use one cache key", async () => 
     files.publish.match(/publish\.js\?v=([^"']+)/)?.[1],
     files.develop.match(/develop\.js\?v=([^"']+)/)?.[1],
     files.app.match(/shared\.js\?v=([^"']+)/)?.[1],
+    files.app.match(/engagement\.js\?v=([^"']+)/)?.[1],
     files.app.match(/search\.js\?v=([^"']+)/)?.[1],
     files.pluginJs.match(/shared\.js\?v=([^"']+)/)?.[1],
+    files.pluginJs.match(/engagement\.js\?v=([^"']+)/)?.[1],
     files.publishJs.match(/shared\.js\?v=([^"']+)/)?.[1],
     files.developJs.match(/shared\.js\?v=([^"']+)/)?.[1],
   ];
@@ -587,6 +591,18 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.readme, /does not grant rights to plugin code, repositories, names, trademarks, logos, screenshots, previews, or other third-party content/);
   assert.match(files.readme, /The marketplace relies on each submitter's rights confirmation\. A listing does not transfer ownership, verify third-party rights, or imply endorsement/);
   assert.match(files.readme, /If you believe a listing or asset infringes your rights,[\s\S]*issues\/new\?template=rights-request\.yml[\s\S]*reviewed or removed/);
+  assert.match(files.readme, /## Engagement Metrics[\s\S]*anonymous aggregate plugin detail views, successful command-copy actions, and hearts[\s\S]*not downloads, installations, unique people, verified votes, quality rankings, or security signals/);
+  assert.match(files.engagementJs, /https:\/\/api\.omarchyplugins\.com\/v1/);
+  assert.match(files.engagementJs, /cache: "no-store",\s*credentials: "omit"/);
+  assert.doesNotMatch(files.engagementJs, /Authorization|Bearer|apiKey|apiToken/);
+  assert.match(files.app, /data-copy-command="\$\{escapeHtml\(plugin\.installCommand\)\}" data-plugin-id="\$\{escapeHtml\(plugin\.id\)\}"/);
+  assert.match(files.app, /if \(!await copyText\(button\.dataset\.copyCommand, button\)\) return;[\s\S]*recordEngagementEvent\(pluginId, "copy"\)/);
+  assert.match(files.pluginJs, /recordPluginView\(plugin\.id\)\.then\(applyAuthoritativeEngagement\)/);
+  assert.match(files.pluginJs, /catch\(\(reason\) => \{[\s\S]*if \(!engagementLoaded\) \{[\s\S]*hidePendingEngagement\(document\)/);
+  assert.match(files.pluginJs, /recordPluginHeart\(plugin\.id\)[\s\S]*showToast\("Heart could not be sent\. Try again\."\)[\s\S]*showToast\("Heart sent\."\)/);
+  assert.match(files.app, /recordPluginHeart\(pluginId\)[\s\S]*showToast\("Heart could not be sent\. Try again\."\)[\s\S]*showToast\("Heart sent\."\)/);
+  assert.match(files.sharedJs, /aria-disabled="true"[\s\S]*button\.disabled = false/);
+  assert.doesNotMatch(files.sharedJs, /hearted \? " disabled"/);
   assert.match(files.rightsRequest, /name: Rights or asset removal request[\s\S]*id: material[\s\S]*id: basis[\s\S]*id: action[\s\S]*made in good faith/);
   assert.match(files.rightsRequest, /Do not include private contact details, identity documents, or other sensitive information/);
   assert.equal((files.readme.match(/^## License$/gm) || []).length, 1);
@@ -893,7 +909,14 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.pluginJs, /item\?\.id === id/);
   const styles = await readFile(new URL("site/assets/css/style.css", root), "utf8");
   assert.doesNotMatch(files.app, /plugin-preview-(?:bar|meta)/);
-  assert.match(styles, /\.plugin-card-body \.plugin-description \{[\s\S]*max-height: 42px;[\s\S]*-webkit-line-clamp: 2;/);
+  assert.match(styles, /\.plugin-card-body \.plugin-description \{[\s\S]*max-height: 21px;[\s\S]*text-overflow: clip; white-space: nowrap;[\s\S]*mask-image: linear-gradient/);
+  assert.match(styles, /\.plugin-card-body \.plugin-description \{[\s\S]*margin: 4px 0 9px;/);
+  assert.match(styles, /\.card-activity-state \{[\s\S]*border-left: 2px solid currentColor;[\s\S]*font-size: 10px;/);
+  assert.doesNotMatch(styles, /\.plugin-title-line \.new-badge/);
+  assert.match(styles, /\.card-social \{[\s\S]*top: 13px;[\s\S]*height: 25px;/);
+  assert.match(styles, /\.card-stars \{[\s\S]*width: 54px;[\s\S]*height: 25px;/);
+  assert.match(styles, /\.plugin-card-actions \.engagement-metric \{[\s\S]*height: 25px;/);
+  assert.match(styles, /\.plugin-heart\.is-celebrating \.heart-glyph \{[\s\S]*animation: heart-confirm 220ms/);
   assert.match(styles, /\.page-meta \.manifest-version \{ min-width: 0; overflow-wrap: anywhere; \}/);
   assert.match(styles, /\.plugin-card-link:focus-visible \{ outline-offset: -2px; \}/);
   assert.match(styles, /\.page-header::before \{[\s\S]*linear-gradient\(90deg, transparent, var\(--line\) 12%, var\(--line\) 88%, transparent\)/);
@@ -916,8 +939,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.doesNotMatch(`${files.publish}\n${files.pluginJs}`, /class="hash"/);
   assert.doesNotMatch(styles, /\.section-title(?:\s|\.|\{)/);
   assert.match(styles, /\[data-theme="light"\] \.plugin-icon, \[data-theme="light"\] \.detail-icon \{ color: var\(--text\); \}/);
-  assert.match(styles, /\[data-theme="light"\] \.new-badge \{ border-color: #b4c96f; background: #b4c96f; \}/);
-  assert.match(styles, /\[data-theme="light"\] \.updated-badge \{ border-color: #ffb000; background: #ffb000; \}/);
+  assert.match(styles, /\.card-activity-state\.is-updated \{ color: var\(--updated\); \}/);
   assert.match(styles, /\[data-theme="light"\] \.aside-meta \.status-label\.is-caution \{[\s\S]*color: #965f00;/);
   assert.match(styles, /\.tree-branch::before, \.tree-branch::after \{[\s\S]*background: currentColor;/);
   assert.match(styles, /\.example-file:last-child \.tree-branch::before \{ bottom: 50%; \}/);
@@ -957,7 +979,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.market-plugin-grid \.plugin-card, \.recent-grid \.plugin-card \{[\s\S]*display: flex;[\s\S]*flex-direction: column; gap: 0;/);
   assert.match(styles, /\.plugin-preview \{[\s\S]*height: 175px; min-height: 0;[\s\S]*flex: 0 0 175px;/);
   assert.match(styles, /\.plugin-card-body \{[\s\S]*display: flex;[\s\S]*min-width: 0;[\s\S]*flex: 1; flex-direction: column;/);
-  assert.match(files.app, /<div class="plugin-card-content">[\s\S]*class="plugin-title-line"[\s\S]*\$\{authorLine\}[\s\S]*class="plugin-description"/);
+  assert.match(files.app, /<div class="plugin-card-content">[\s\S]*class="plugin-title-line"[\s\S]*\$\{authorLine\}[\s\S]*class="plugin-description"[\s\S]*\$\{activityState\}/);
   assert.match(styles, /\.plugin-card-bottom \{[\s\S]*margin-top: auto;/);
   assert.match(styles, /\.plugin-author button \{[\s\S]*z-index: 3/);
   assert.match(styles, /\.plugin-author button \{[\s\S]*min-height: 24px/);

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -1,0 +1,564 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  engagementApiBaseUrl,
+  hasPluginHeart,
+  loadEngagementStats,
+  normalizeEngagementStats,
+  recordEngagementEvent,
+  recordPluginHeart,
+  recordPluginView,
+} from "../site/assets/js/engagement.js";
+import {
+  engagementSummary,
+  formatEngagementCount,
+  formatStars,
+  hidePendingEngagement,
+  pluginHeartButton,
+} from "../site/assets/js/shared.js";
+import {
+  engagementUpsertStatement,
+  handleRequest,
+  parseEngagementEvent,
+} from "../worker/src/index.js";
+
+function responseJson(value, init = {}) {
+  return new Response(JSON.stringify(value), {
+    status: init.status || 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeDatabase(rows = [], {
+  recorded = { plugin_id: "example.plugin" },
+  totals = { views: 9, copies: 4, hearts: 3 },
+  batchError = null,
+} = {}) {
+  const calls = [];
+  return {
+    calls,
+    prepare(sql) {
+      const statement = {
+        sql,
+        values: [],
+        bind(...values) {
+          statement.values = values;
+          return statement;
+        },
+        async all() {
+          calls.push({ operation: "all", sql, values: statement.values });
+          return { results: rows };
+        },
+      };
+      return statement;
+    },
+    async batch(statements) {
+      calls.push(...statements.map((statement) => ({
+        operation: "batch",
+        sql: statement.sql,
+        values: statement.values,
+      })));
+      if (batchError) throw batchError;
+      return statements.map((statement) => ({
+        success: true,
+        results: statement.sql.includes("RETURNING plugin_id")
+          ? (recorded ? [recorded] : [])
+          : [totals],
+      }));
+    },
+  };
+}
+
+function fakeRateLimiter(success = true) {
+  const keys = [];
+  return {
+    keys,
+    async limit({ key }) {
+      keys.push(key);
+      return { success };
+    },
+  };
+}
+
+const productionLocation = { hostname: "omarchyplugins.com" };
+const localLocation = { hostname: "127.0.0.1" };
+
+test("engagement API routing is explicit and disabled on unrecognized hosts", () => {
+  assert.equal(engagementApiBaseUrl(productionLocation), "https://api.omarchyplugins.com/v1");
+  assert.equal(engagementApiBaseUrl(localLocation), "http://127.0.0.1:8787/v1");
+  assert.equal(engagementApiBaseUrl({ hostname: "preview.example" }), "");
+});
+
+test("engagement counts and summaries stay compact, accessible, and command-aware", () => {
+  assert.equal(formatEngagementCount(999), "999");
+  assert.equal(formatEngagementCount(1000), "1k");
+  assert.equal(formatEngagementCount(1200), "1.2k");
+  assert.equal(formatEngagementCount(12_400), "12k");
+  assert.equal(formatEngagementCount(1_500_000), "1.5m");
+  assert.equal(formatStars(1000), "1k");
+  assert.equal(formatStars(1200), "1.2k");
+  const installable = engagementSummary({
+    id: "example.plugin",
+    installCommand: "omarchy plugin add example",
+  }, { views: 1200, copies: 4 }, { detail: true });
+  assert.match(installable, /data-plugin-engagement="example\.plugin"/);
+  assert.match(installable, /class="engagement-glyph" aria-hidden="true"></);
+  assert.match(installable, /class="copy-icon engagement-copy-icon" aria-hidden="true"><\/span>/);
+  assert.match(installable, /data-engagement-accessible>1200 marketplace detail views</);
+  assert.match(installable, /data-engagement-accessible>4 successful command copies</);
+  assert.match(installable, />1\.2k</);
+  assert.match(installable, /class="engagement-visual" aria-hidden="true">[\s\S]*class="engagement-name">views</);
+  const manual = engagementSummary({ id: "manual.plugin", installCommand: "" }, {}, { pending: true });
+  assert.match(manual, /data-engagement-metric="views"/);
+  assert.doesNotMatch(manual, /data-engagement-metric="copies"/);
+  assert.match(manual, /class="plugin-engagement is-pending"/);
+  assert.match(manual, /aria-busy="true"/);
+
+  const heart = pluginHeartButton({ id: "example.plugin", name: "Example" }, { hearts: 12 }, {
+    hearted: true,
+  });
+  assert.match(heart, /data-plugin-heart="example\.plugin"/);
+  assert.match(heart, /data-heart-glyph aria-hidden="true"></);
+  assert.match(heart, /aria-pressed="true" aria-disabled="true"/);
+  assert.doesNotMatch(heart, /\sdisabled/);
+  assert.match(heart, />12<\/span>/);
+});
+
+test("engagement stats accept only safe IDs and non-negative integer counts", () => {
+  assert.deepEqual(normalizeEngagementStats({
+    plugins: {
+      "example.plugin": { views: 12.9, copies: "4", hearts: 7.8 },
+      "bad id": { views: 99, copies: 99, hearts: 99 },
+      __proto__: { views: 99, copies: 99, hearts: 99 },
+      constructor: { views: 99, copies: 99, hearts: 99 },
+      negative: { views: -1, copies: Number.NaN, hearts: -4 },
+    },
+  }), {
+    "example.plugin": { views: 12, copies: 4, hearts: 7 },
+    negative: { views: 0, copies: 0, hearts: 0 },
+  });
+  assert.deepEqual(normalizeEngagementStats({ plugins: [] }), {});
+});
+
+test("engagement client loads public stats without credentials", async () => {
+  let request;
+  const result = await loadEngagementStats({
+    locationRef: productionLocation,
+    fetchImpl: async (...values) => {
+      request = values;
+      return responseJson({ plugins: { "example.plugin": { views: 2, copies: 1, hearts: 6 } } });
+    },
+  });
+  assert.deepEqual(result, { "example.plugin": { views: 2, copies: 1, hearts: 6 } });
+  assert.equal(request[0], "https://api.omarchyplugins.com/v1/stats");
+  assert.equal(request[1].cache, "no-store");
+  assert.equal(request[1].credentials, "omit");
+  assert.equal(request[1].headers.Authorization, undefined);
+});
+
+test("engagement events contain only the plugin ID and fixed action type", async () => {
+  let request;
+  const recorded = await recordEngagementEvent("example.plugin", "copy", {
+    locationRef: productionLocation,
+    fetchImpl: async (...values) => {
+      request = values;
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 4, hearts: 3 },
+      }, { status: 202 });
+    },
+  });
+  assert.deepEqual(recorded, {
+    recorded: true,
+    stats: { views: 9, copies: 4, hearts: 3 },
+  });
+  assert.equal(request[0], "https://api.omarchyplugins.com/v1/events");
+  assert.deepEqual(JSON.parse(request[1].body), {
+    pluginId: "example.plugin",
+    type: "copy",
+  });
+  assert.equal(request[1].credentials, "omit");
+  assert.equal(request[1].headers.Authorization, undefined);
+  assert.equal(await recordEngagementEvent("bad id", "copy", {
+    locationRef: productionLocation,
+    fetchImpl: async () => { throw new Error("must not run"); },
+  }), null);
+});
+
+test("plugin views are recorded once per browser session and retry after failure", async () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+  let requests = 0;
+  const options = {
+    storage,
+    locationRef: productionLocation,
+    fetchImpl: async () => {
+      requests += 1;
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 4, hearts: 3 },
+      }, { status: 202 });
+    },
+  };
+  assert.deepEqual(await recordPluginView("example.plugin", options), {
+    recorded: true,
+    stats: { views: 9, copies: 4, hearts: 3 },
+  });
+  assert.deepEqual(await recordPluginView("example.plugin", options), {
+    recorded: false,
+    stats: null,
+  });
+  assert.equal(requests, 1);
+
+  const failing = {
+    ...options,
+    fetchImpl: async () => {
+      requests += 1;
+      return responseJson({ error: "unavailable" }, { status: 503 });
+    },
+  };
+  assert.equal(await recordPluginView("another.plugin", failing), null);
+  assert.equal(values.has("omarchy-plugin-view:another.plugin"), false);
+});
+
+test("plugin hearts are recorded once per browser and only persisted after success", async () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+  let requests = 0;
+  const options = {
+    storage,
+    locationRef: productionLocation,
+    fetchImpl: async (_url, request) => {
+      requests += 1;
+      assert.deepEqual(JSON.parse(request.body), {
+        pluginId: "example.plugin",
+        type: "heart",
+      });
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 4, hearts: 5 },
+      }, { status: 202 });
+    },
+  };
+  assert.equal(hasPluginHeart("example.plugin", storage), false);
+  assert.deepEqual(await recordPluginHeart("example.plugin", options), {
+    recorded: true,
+    stats: { views: 9, copies: 4, hearts: 5 },
+  });
+  assert.equal(hasPluginHeart("example.plugin", storage), true);
+  assert.deepEqual(await recordPluginHeart("example.plugin", options), {
+    recorded: false,
+    stats: null,
+  });
+  assert.equal(requests, 1);
+
+  const failed = await recordPluginHeart("failed.plugin", {
+    ...options,
+    fetchImpl: async () => responseJson({ error: "unavailable" }, { status: 503 }),
+  });
+  assert.equal(failed, null);
+  assert.equal(hasPluginHeart("failed.plugin", storage), false);
+});
+
+test("parallel heart attempts share one in-flight request", async () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+  let requests = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const options = {
+    storage,
+    locationRef: productionLocation,
+    fetchImpl: async () => {
+      requests += 1;
+      await gate;
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 4, hearts: 6 },
+      }, { status: 202 });
+    },
+  };
+  const first = recordPluginHeart("parallel.plugin", options);
+  const second = recordPluginHeart("parallel.plugin", options);
+  assert.equal(requests, 1);
+  release();
+  assert.deepEqual(await Promise.all([first, second]), [
+    { recorded: true, stats: { views: 9, copies: 4, hearts: 6 } },
+    { recorded: true, stats: { views: 9, copies: 4, hearts: 6 } },
+  ]);
+  assert.equal(hasPluginHeart("parallel.plugin", storage), true);
+});
+
+test("failed engagement loads can clear pending UI state", () => {
+  const elements = [
+    { hidden: false, classList: { remove(value) { assert.equal(value, "is-pending"); } }, removeAttribute(value) { assert.equal(value, "aria-busy"); } },
+    { hidden: false, classList: { remove(value) { assert.equal(value, "is-pending"); } }, removeAttribute(value) { assert.equal(value, "aria-busy"); } },
+  ];
+  hidePendingEngagement({
+    querySelectorAll(selector) {
+      assert.equal(selector, ".plugin-engagement.is-pending, .plugin-heart.is-pending");
+      return elements;
+    },
+  });
+  assert.equal(elements.every((element) => element.hidden), true);
+});
+
+test("Worker event parsing rejects extra fields and unsupported values", () => {
+  assert.deepEqual(parseEngagementEvent({ pluginId: "example.plugin", type: "view" }), {
+    pluginId: "example.plugin",
+    type: "view",
+  });
+  assert.deepEqual(parseEngagementEvent({ pluginId: "example.plugin", type: "heart" }), {
+    pluginId: "example.plugin",
+    type: "heart",
+  });
+  assert.equal(parseEngagementEvent({ pluginId: "example.plugin", type: "install" }), null);
+  assert.equal(parseEngagementEvent({ pluginId: "__proto__", type: "copy" }), null);
+  assert.equal(parseEngagementEvent({ pluginId: "example.plugin", type: "copy", token: "secret" }), null);
+});
+
+test("Worker exposes aggregate stats with restricted CORS and no credentials", async () => {
+  const database = fakeDatabase([
+    { plugin_id: "example.plugin", views: 8, copies: 3, hearts: 5 },
+    { plugin_id: "bad id", views: 99, copies: 99, hearts: 99 },
+  ]);
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/stats", {
+    headers: { Origin: "https://omarchyplugins.com" },
+  }), { ENGAGEMENT_DB: database });
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.deepEqual(await response.json(), {
+    schemaVersion: 1,
+    plugins: { "example.plugin": { views: 8, copies: 3, hearts: 5 } },
+  });
+  assert.equal(database.calls[0].operation, "all");
+});
+
+test("Worker rejects streamed oversized event bodies without buffering or catalog access", async () => {
+  const database = fakeDatabase();
+  const rateLimiter = fakeRateLimiter();
+  const request = new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "copy", padding: "x".repeat(1100) }),
+  });
+  assert.equal(request.headers.has("Content-Length"), false);
+  const response = await handleRequest(request, {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: rateLimiter,
+  }, {
+    fetchImpl: async () => { throw new Error("must not fetch"); },
+  });
+  assert.equal(response.status, 413);
+  assert.equal(database.calls.length, 0);
+  assert.equal(rateLimiter.keys.length, 1);
+});
+
+test("Worker rate limiting runs before request body, catalog, and D1 access", async () => {
+  const database = fakeDatabase();
+  const rateLimiter = fakeRateLimiter(false);
+  let bodyAccessed = false;
+  const request = {
+    url: "https://api.omarchyplugins.com/v1/events",
+    method: "POST",
+    headers: new Headers({
+      "CF-Connecting-IP": "192.0.2.1",
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    }),
+    get body() {
+      bodyAccessed = true;
+      throw new Error("body must not be accessed");
+    },
+  };
+  const response = await handleRequest(request, {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: rateLimiter,
+  }, {
+    fetchImpl: async () => { throw new Error("catalog must not be fetched"); },
+  });
+  assert.equal(response.status, 429);
+  assert.equal(bodyAccessed, false);
+  assert.equal(response.headers.get("Retry-After"), "60");
+  assert.deepEqual(rateLimiter.keys, ["events:192.0.2.1"]);
+  assert.equal(database.calls.length, 0);
+});
+
+test("Worker treats the daily ceiling as a real no-op", async () => {
+  const database = fakeDatabase([], { recorded: null });
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "view" }),
+  }), {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    CATALOG_URL: "https://catalog-limit.example/catalog.json",
+  }, {
+    fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
+  });
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), { recorded: false, reason: "daily-limit" });
+  assert.equal(database.calls.length, 2);
+  assert.equal(database.calls.every((call) => call.operation === "batch"), true);
+});
+
+test("Worker returns no success when its transactional write-and-totals batch fails", async () => {
+  const database = fakeDatabase([], { batchError: new Error("totals failed") });
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "heart" }),
+  }), {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    CATALOG_URL: "https://catalog-batch.example/catalog.json",
+  }, {
+    fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: "Event service unavailable" });
+  assert.equal(database.calls.length, 2);
+  assert.equal(database.calls.every((call) => call.operation === "batch"), true);
+  assert.match(database.calls[0].sql, /RETURNING plugin_id/);
+  assert.match(database.calls[1].sql, /SELECT SUM\(views\)/);
+});
+
+test("Worker upserts never lower unrelated counters after a limit reduction", async () => {
+  const migration = await readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8");
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(migration);
+    database.prepare(`
+      INSERT INTO plugin_engagement_daily (plugin_id, day, views, copies, hearts)
+      VALUES (?1, ?2, ?3, ?4, ?5)
+    `).run("example.plugin", "2026-08-16", 10_000, 499, 700);
+
+    const updated = database.prepare(engagementUpsertStatement())
+      .get("example.plugin", "2026-08-16", 0, 1, 0, 500);
+    assert.equal(updated.plugin_id, "example.plugin");
+    const afterCopy = database.prepare(`
+      SELECT views, copies, hearts FROM plugin_engagement_daily WHERE plugin_id = ?1
+    `).get("example.plugin");
+    assert.deepEqual({ ...afterCopy }, { views: 10_000, copies: 500, hearts: 700 });
+
+    const capped = database.prepare(engagementUpsertStatement())
+      .get("example.plugin", "2026-08-16", 0, 0, 1, 500);
+    assert.equal(capped, undefined);
+    const afterHeart = database.prepare(`
+      SELECT views, copies, hearts FROM plugin_engagement_daily WHERE plugin_id = ?1
+    `).get("example.plugin");
+    assert.deepEqual({ ...afterHeart }, { views: 10_000, copies: 500, hearts: 700 });
+  } finally {
+    database.close();
+  }
+});
+
+test("Worker caches aggregate stats at the edge while disabling browser storage", async () => {
+  const database = fakeDatabase([{ plugin_id: "example.plugin", views: 8, copies: 3, hearts: 5 }]);
+  const values = new Map();
+  const storedCacheControls = [];
+  const cache = {
+    async match(request) {
+      return values.get(request.url)?.clone();
+    },
+    async put(request, response) {
+      storedCacheControls.push(response.headers.get("Cache-Control"));
+      values.set(request.url, response.clone());
+    },
+  };
+  const pending = [];
+  const options = {
+    cache,
+    waitUntil: (promise) => pending.push(promise),
+  };
+  const request = new Request("https://api.omarchyplugins.com/v1/stats", {
+    headers: { Origin: "https://omarchyplugins.com" },
+  });
+  const first = await handleRequest(request, { ENGAGEMENT_DB: database }, options);
+  assert.equal(first.headers.get("Access-Control-Allow-Origin"), "*");
+  assert.equal(first.headers.get("Cache-Control"), "no-store");
+  await Promise.all(pending);
+  assert.deepEqual(storedCacheControls, ["public, max-age=60, s-maxage=300"]);
+  const second = await handleRequest(request, { ENGAGEMENT_DB: database }, options);
+  assert.equal(second.status, 200);
+  assert.equal(second.headers.get("Cache-Control"), "no-store");
+  assert.equal(database.calls.length, 1);
+});
+
+test("Worker records only known catalog plugins from allowed origins", async () => {
+  const database = fakeDatabase();
+  const rateLimiter = fakeRateLimiter();
+  const env = {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: rateLimiter,
+    CATALOG_URL: "https://catalog-one.example/catalog.json",
+    DAILY_EVENT_LIMIT: "500",
+  };
+  const fetchImpl = async () => responseJson({ plugins: [{ id: "example.plugin" }] });
+  const request = (pluginId, origin = "https://omarchyplugins.com", type = "heart") => new Request(
+    "https://api.omarchyplugins.com/v1/events",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: origin },
+      body: JSON.stringify({ pluginId, type }),
+    },
+  );
+
+  const response = await handleRequest(request("example.plugin"), env, { fetchImpl });
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), {
+    recorded: true,
+    plugin: { views: 9, copies: 4, hearts: 3 },
+  });
+  assert.equal(database.calls[0].operation, "batch");
+  assert.deepEqual(database.calls[0].values.slice(0, 1), ["example.plugin"]);
+  assert.deepEqual(database.calls[0].values.slice(2), [0, 0, 1, 500]);
+  assert.match(database.calls[1].sql, /SELECT SUM\(views\)/);
+  assert.match(rateLimiter.keys[0], /^events:/);
+
+  const unknown = await handleRequest(request("unknown.plugin"), env, { fetchImpl });
+  assert.equal(unknown.status, 404);
+  const forbidden = await handleRequest(request("example.plugin", "https://attacker.example"), env, { fetchImpl });
+  assert.equal(forbidden.status, 403);
+  assert.equal(database.calls.length, 2);
+});
+
+test("Worker deployment files contain placeholders but no credentials", async () => {
+  const root = new URL("../", import.meta.url);
+  const [ignore, template, migration] = await Promise.all([
+    readFile(new URL(".gitignore", root), "utf8"),
+    readFile(new URL("worker/wrangler.example.jsonc", root), "utf8"),
+    readFile(new URL("worker/migrations/0001_plugin_engagement.sql", root), "utf8"),
+  ]);
+  assert.match(ignore, /worker\/wrangler\.jsonc/);
+  assert.match(ignore, /worker\/\.dev\.vars\*/);
+  assert.match(template, /REPLACE_WITH_D1_DATABASE_ID/);
+  assert.match(template, /"name": "ENGAGEMENT_RATE_LIMITER"/);
+  assert.match(template, /"simple": \{ "limit": 60, "period": 60 \}/);
+  assert.doesNotMatch(template, /api[_-]?token|account[_-]?token|bearer\s+[A-Za-z0-9]/i);
+  assert.match(migration, /hearts INTEGER NOT NULL DEFAULT 0/);
+  assert.match(migration, /PRIMARY KEY \(plugin_id, day\)/);
+});

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,51 @@
+# Engagement Worker
+
+This Cloudflare Worker stores anonymous aggregate marketplace engagement in D1.
+It records three actions:
+
+- `view`: a successfully rendered plugin detail page, guarded once per browser session
+- `copy`: a successful plugin command copy action
+- `heart`: an anonymous positive reaction, guarded once per plugin in local browser storage
+
+These values describe marketplace activity. They are not downloads, installations,
+unique people, verified votes, quality signals, or security signals.
+
+## Privacy and trust boundary
+
+The application does not send or store accounts, cookies, IP addresses, user-agent
+strings, command text, repository URLs, or plugin metadata. Event bodies contain only
+a catalog plugin ID and the fixed action type. Cloudflare still processes normal request
+metadata as the network provider under the account's Cloudflare configuration.
+
+The public API contains no credentials. D1 is available only through the Worker binding.
+Keep the real `wrangler.jsonc`, `.dev.vars`, local Wrangler state, and all credentials out
+of version control.
+
+## Local configuration
+
+Copy `wrangler.example.jsonc` to the ignored `wrangler.jsonc`, create the D1 database,
+and replace only the local `REPLACE_WITH_D1_DATABASE_ID` value. Apply the migration
+before starting the Worker on `127.0.0.1:8787`.
+
+The production custom-domain route is intentionally commented out in the template.
+Verify a workers.dev deployment before adding `api.omarchyplugins.com` to the local
+configuration.
+
+## API
+
+- `GET /v1/stats` returns aggregate counts keyed by plugin ID.
+- `POST /v1/events` accepts `{ "pluginId": "...", "type": "view" }`,
+  `{ "pluginId": "...", "type": "copy" }`, or
+  `{ "pluginId": "...", "type": "heart" }` from an allowed marketplace origin.
+
+The Worker validates plugin IDs against the published marketplace catalog, applies a
+Cloudflare edge rate limit before catalog or D1 access, and enforces a daily ceiling per
+plugin and event type. The rate limiter uses the request IP as an ephemeral Cloudflare
+edge key; the application does not write that key to D1. Public stats are cached at the
+edge for up to five minutes, while browser storage is disabled and successful event
+responses return authoritative fresh counts for immediate UI feedback.
+
+Anonymous public counters remain inherently susceptible to manipulation. Local browser
+storage is only a best-effort repeat guard and can be cleared or bypassed. Hearts must be
+presented as anonymous reactions, never as unique or verified votes, trust, or quality
+rankings.

--- a/worker/migrations/0001_plugin_engagement.sql
+++ b/worker/migrations/0001_plugin_engagement.sql
@@ -1,0 +1,14 @@
+CREATE TABLE plugin_engagement_daily (
+  plugin_id TEXT NOT NULL CHECK (
+    length(plugin_id) BETWEEN 1 AND 128
+    AND plugin_id NOT GLOB '*[^A-Za-z0-9._-]*'
+  ),
+  day TEXT NOT NULL CHECK (
+    length(day) = 10
+    AND day GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+  ),
+  views INTEGER NOT NULL DEFAULT 0 CHECK (views >= 0),
+  copies INTEGER NOT NULL DEFAULT 0 CHECK (copies >= 0),
+  hearts INTEGER NOT NULL DEFAULT 0 CHECK (hearts >= 0),
+  PRIMARY KEY (plugin_id, day)
+) WITHOUT ROWID;

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,322 @@
+const allowedOrigins = new Set([
+  "https://omarchyplugins.com",
+  "https://www.omarchyplugins.com",
+  "http://127.0.0.1:4173",
+  "http://localhost:4173",
+]);
+const pluginIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const unsafeObjectKeys = new Set(["__proto__", "constructor", "prototype"]);
+const eventTypes = new Set(["view", "copy", "heart"]);
+const defaultCatalogUrl = "https://omarchyplugins.com/catalog.json";
+const defaultDailyEventLimit = 10_000;
+const catalogCacheLifetime = 5 * 60 * 1000;
+let catalogCache = { url: "", expiresAt: 0, pluginIds: new Set() };
+
+function validPluginId(value) {
+  return pluginIdPattern.test(value) && !unsafeObjectKeys.has(value.toLowerCase());
+}
+
+function corsHeaders(origin) {
+  if (!allowedOrigins.has(origin)) return { Vary: "Origin" };
+  return {
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+}
+
+function json(payload, status = 200, headers = {}) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+      ...headers,
+    },
+  });
+}
+
+function eventLimit(value) {
+  const limit = Math.trunc(Number(value));
+  return Number.isSafeInteger(limit) && limit > 0
+    ? Math.min(limit, 1_000_000)
+    : defaultDailyEventLimit;
+}
+
+function validCatalogUrl(value) {
+  try {
+    const url = new URL(value || defaultCatalogUrl);
+    const local = ["127.0.0.1", "localhost"].includes(url.hostname);
+    if (url.protocol !== "https:" && !(local && url.protocol === "http:")) return "";
+    return url.href;
+  } catch {
+    return "";
+  }
+}
+
+export function parseEngagementEvent(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const pluginId = String(value.pluginId || "");
+  const type = String(value.type || "");
+  if (
+    !validPluginId(pluginId)
+    || !eventTypes.has(type)
+    || Object.keys(value).some((key) => !["pluginId", "type"].includes(key))
+  ) return null;
+  return { pluginId, type };
+}
+
+async function catalogPluginIds(env, fetchImpl, now = Date.now()) {
+  const url = validCatalogUrl(env.CATALOG_URL);
+  if (!url) throw new Error("CATALOG_URL is invalid");
+  if (catalogCache.url === url && catalogCache.expiresAt > now) {
+    return catalogCache.pluginIds;
+  }
+  const response = await fetchImpl(url, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) throw new Error(`Catalog returned ${response.status}`);
+  const catalog = await response.json();
+  if (!catalog || !Array.isArray(catalog.plugins)) throw new Error("Catalog response is invalid");
+  const pluginIds = new Set(
+    catalog.plugins
+      .map((plugin) => plugin?.id)
+      .filter((pluginId) => validPluginId(String(pluginId || ""))),
+  );
+  catalogCache = { url, expiresAt: now + catalogCacheLifetime, pluginIds };
+  return pluginIds;
+}
+
+function safeCount(value) {
+  const count = Math.trunc(Number(value));
+  return Number.isSafeInteger(count) && count >= 0 ? count : 0;
+}
+
+function normalizedRows(results) {
+  const plugins = {};
+  for (const row of results || []) {
+    const pluginId = String(row.plugin_id || "");
+    if (!validPluginId(pluginId)) continue;
+    plugins[pluginId] = {
+      views: safeCount(row.views),
+      copies: safeCount(row.copies),
+      hearts: safeCount(row.hearts),
+    };
+  }
+  return plugins;
+}
+
+const engagementTotalsSql = `
+  SELECT SUM(views) AS views, SUM(copies) AS copies, SUM(hearts) AS hearts
+  FROM plugin_engagement_daily
+  WHERE plugin_id = ?1
+`;
+
+function normalizedTotals(row) {
+  return {
+    views: safeCount(row?.views),
+    copies: safeCount(row?.copies),
+    hearts: safeCount(row?.hearts),
+  };
+}
+
+async function statsResponse(env) {
+  const result = await env.ENGAGEMENT_DB.prepare(`
+    SELECT plugin_id, SUM(views) AS views, SUM(copies) AS copies, SUM(hearts) AS hearts
+    FROM plugin_engagement_daily
+    GROUP BY plugin_id
+    ORDER BY plugin_id
+  `).all();
+  return json(
+    { schemaVersion: 1, plugins: normalizedRows(result.results) },
+    200,
+    {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=60, s-maxage=300",
+    },
+  );
+}
+
+function browserStatsResponse(response) {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function cachedStatsResponse(request, env, cache, waitUntil) {
+  const cacheKey = new Request(new URL("/v1/stats", request.url), { method: "GET" });
+  if (cache?.match) {
+    const cached = await cache.match(cacheKey);
+    if (cached) return browserStatsResponse(cached);
+  }
+  const response = await statsResponse(env);
+  if (cache?.put) {
+    const write = cache.put(cacheKey, response.clone()).catch(() => {});
+    waitUntil(write);
+  }
+  return browserStatsResponse(response);
+}
+
+async function readLimitedBody(request, limit) {
+  if (!request.body) return "";
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return text + decoder.decode();
+      size += value.byteLength;
+      if (size > limit) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const engagementUpsertSql = `
+  INSERT INTO plugin_engagement_daily (plugin_id, day, views, copies, hearts)
+  VALUES (?1, ?2, ?3, ?4, ?5)
+  ON CONFLICT(plugin_id, day) DO UPDATE SET
+    views = CASE WHEN excluded.views > 0
+      THEN MIN(plugin_engagement_daily.views + excluded.views, ?6)
+      ELSE plugin_engagement_daily.views END,
+    copies = CASE WHEN excluded.copies > 0
+      THEN MIN(plugin_engagement_daily.copies + excluded.copies, ?6)
+      ELSE plugin_engagement_daily.copies END,
+    hearts = CASE WHEN excluded.hearts > 0
+      THEN MIN(plugin_engagement_daily.hearts + excluded.hearts, ?6)
+      ELSE plugin_engagement_daily.hearts END
+  WHERE
+    (excluded.views > 0 AND plugin_engagement_daily.views < ?6)
+    OR (excluded.copies > 0 AND plugin_engagement_daily.copies < ?6)
+    OR (excluded.hearts > 0 AND plugin_engagement_daily.hearts < ?6)
+  RETURNING plugin_id
+`;
+
+export function engagementUpsertStatement() {
+  return engagementUpsertSql;
+}
+
+async function eventResponse(request, env, origin, fetchImpl) {
+  if (!allowedOrigins.has(origin)) return json({ error: "Origin not allowed" }, 403);
+  const contentType = request.headers.get("Content-Type") || "";
+  const contentLength = Number(request.headers.get("Content-Length") || 0);
+  if (!contentType.toLowerCase().startsWith("application/json")) {
+    return json({ error: "Expected a JSON request" }, 415, corsHeaders(origin));
+  }
+  if (Number.isFinite(contentLength) && contentLength > 1024) {
+    return json({ error: "Request body too large" }, 413, corsHeaders(origin));
+  }
+
+  if (!env.ENGAGEMENT_RATE_LIMITER?.limit) {
+    return json({ error: "Rate limiter unavailable" }, 503, corsHeaders(origin));
+  }
+  const actor = request.headers.get("CF-Connecting-IP") || "unknown";
+  const rateLimit = await env.ENGAGEMENT_RATE_LIMITER.limit({ key: `events:${actor}` });
+  if (!rateLimit.success) {
+    return json(
+      { error: "Rate limit exceeded" },
+      429,
+      { ...corsHeaders(origin), "Retry-After": "60" },
+    );
+  }
+
+  let event;
+  try {
+    const body = await readLimitedBody(request, 1024);
+    if (body === null) {
+      return json({ error: "Request body too large" }, 413, corsHeaders(origin));
+    }
+    event = parseEngagementEvent(JSON.parse(body));
+  } catch {
+    event = null;
+  }
+  if (!event) return json({ error: "Invalid engagement event" }, 400, corsHeaders(origin));
+
+  let pluginIds;
+  try {
+    pluginIds = await catalogPluginIds(env, fetchImpl);
+  } catch {
+    return json({ error: "Plugin catalog unavailable" }, 503, corsHeaders(origin));
+  }
+  if (!pluginIds.has(event.pluginId)) {
+    return json({ error: "Unknown plugin" }, 404, corsHeaders(origin));
+  }
+
+  const day = new Date().toISOString().slice(0, 10);
+  const views = event.type === "view" ? 1 : 0;
+  const copies = event.type === "copy" ? 1 : 0;
+  const hearts = event.type === "heart" ? 1 : 0;
+  const limit = eventLimit(env.DAILY_EVENT_LIMIT);
+  const [writeResult, totalsResult] = await env.ENGAGEMENT_DB.batch([
+    env.ENGAGEMENT_DB.prepare(engagementUpsertSql)
+      .bind(event.pluginId, day, views, copies, hearts, limit),
+    env.ENGAGEMENT_DB.prepare(engagementTotalsSql).bind(event.pluginId),
+  ]);
+
+  if (!writeResult?.results?.length) {
+    return json({ recorded: false, reason: "daily-limit" }, 202, corsHeaders(origin));
+  }
+  return json({
+    recorded: true,
+    plugin: normalizedTotals(totalsResult?.results?.[0]),
+  }, 202, corsHeaders(origin));
+}
+
+export async function handleRequest(request, env, {
+  fetchImpl = fetch,
+  cache = globalThis.caches?.default,
+  waitUntil = () => {},
+} = {}) {
+  if (!env?.ENGAGEMENT_DB) return json({ error: "Service unavailable" }, 503);
+  const url = new URL(request.url);
+  const origin = request.headers.get("Origin") || "";
+
+  if (request.method === "OPTIONS") {
+    if (!allowedOrigins.has(origin)) return new Response(null, { status: 403 });
+    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+  }
+  if (url.pathname === "/v1/stats") {
+    if (request.method !== "GET") {
+      return json({ error: "Method not allowed" }, 405, { Allow: "GET", ...corsHeaders(origin) });
+    }
+    try {
+      return await cachedStatsResponse(request, env, cache, waitUntil);
+    } catch {
+      return json({ error: "Stats unavailable" }, 503, corsHeaders(origin));
+    }
+  }
+  if (url.pathname === "/v1/events") {
+    if (request.method !== "POST") {
+      return json({ error: "Method not allowed" }, 405, { Allow: "POST", ...corsHeaders(origin) });
+    }
+    try {
+      return await eventResponse(request, env, origin, fetchImpl);
+    } catch {
+      return json({ error: "Event service unavailable" }, 503, corsHeaders(origin));
+    }
+  }
+  return json({ error: "Not found" }, 404, corsHeaders(origin));
+}
+
+export default {
+  fetch(request, env, context) {
+    return handleRequest(request, env, {
+      cache: globalThis.caches?.default,
+      waitUntil: context.waitUntil.bind(context),
+    });
+  },
+};

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://unpkg.com/wrangler@4.123.0/config-schema.json",
+  "name": "omarchy-plugin-engagement",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-15",
+  "workers_dev": true,
+  "vars": {
+    "CATALOG_URL": "https://omarchyplugins.com/catalog.json",
+    "DAILY_EVENT_LIMIT": "10000"
+  },
+  "d1_databases": [
+    {
+      "binding": "ENGAGEMENT_DB",
+      "database_name": "omarchy-plugin-engagement",
+      "database_id": "REPLACE_WITH_D1_DATABASE_ID",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "ratelimits": [
+    {
+      "name": "ENGAGEMENT_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 60, "period": 60 }
+    }
+  ],
+
+  // Add this only after the workers.dev deployment has been verified:
+  // "routes": [
+  //   { "pattern": "api.omarchyplugins.com", "custom_domain": true }
+  // ]
+}


### PR DESCRIPTION
## Summary

- add anonymous aggregate plugin detail views, successful command-copy counts, and hearts
- display resilient engagement metrics on marketplace cards and plugin detail pages
- add a rate-limited Cloudflare Worker and D1 migration with catalog validation and daily limits
- refine card status, tag, description, and social-metric presentation

## Privacy and semantics

- events contain only the catalog plugin ID and fixed event type
- D1 stores daily aggregate counters only
- views are not unique users, copies are not downloads or installations, and hearts are not verified votes

## Verification

- `npm test` — 122/122 passed
- Wrangler dry-run and local D1 runtime checks passed
- browser layout matrix passed at 10 viewport widths
- production Worker smoke checks passed on the custom domain and workers.dev
- final independent review reported 0 actionable findings
