### PR TITLE
Use portable engagement icons

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -877,9 +877,8 @@ svg {
   font-variant-numeric: tabular-nums; line-height: 1; cursor: pointer;
 }
 .social-glyph {
-  display: inline-grid; width: 13px; height: 13px; color: var(--accent); font-family: var(--mono);
-  font-size: 14px; font-weight: 500; line-height: 1; place-items: center;
-  transform: translateY(-1px);
+  display: block; width: 13px; height: 13px; flex: none; color: var(--accent);
+  fill: currentColor; stroke: none; transform: translateY(-1px);
 }
 .star-glyph { color: var(--updated); }
 .social-count { display: inline-flex; align-items: center; justify-content: center; line-height: 11px; }
@@ -899,8 +898,7 @@ svg {
 .engagement-metric, .engagement-visual { display: inline-flex; align-items: center; white-space: nowrap; }
 .engagement-visual { gap: 5px; }
 .engagement-glyph {
-  display: inline-grid; width: 13px; height: 13px; color: var(--faint); font-family: var(--mono);
-  font-size: 14px; font-weight: 500; line-height: 1; place-items: center;
+  display: block; width: 13px; height: 13px; flex: none; color: var(--faint); stroke-width: 1.8;
 }
 .engagement-copy-icon { width: 13px; height: 13px; color: var(--faint); }
 .detail-engagement-cluster {

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -20,14 +20,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-04";
+} from "./shared.js?v=20260816-05";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordEngagementEvent,
   recordPluginHeart,
-} from "./engagement.js?v=20260816-04";
+} from "./engagement.js?v=20260816-05";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -50,7 +50,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260816-04";
+} from "./search.js?v=20260816-05";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
@@ -610,7 +610,7 @@ function pluginCard(plugin, { showNew = false } = {}) {
     : `<div class="plugin-preview" aria-hidden="true">
         <span class="plugin-preview-mark">${escapeHtml(plugin.initials)}</span>
       </div>`;
-  const stars = plugin.builtIn ? "" : `<span class="card-stars" title="Repository stars" aria-label="${formatStars(plugin.stars)} repository stars"><span class="social-glyph star-glyph" aria-hidden="true"></span><span class="social-count" aria-hidden="true">${formatStars(plugin.stars)}</span></span>`;
+  const stars = plugin.builtIn ? "" : `<span class="card-stars" title="Repository stars" aria-label="${formatStars(plugin.stars)} repository stars"><svg class="social-glyph star-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.8 5.7 6.3.9-4.6 4.5 1.1 6.3-5.6-3-5.6 3 1.1-6.3-4.6-4.5 6.3-.9Z"/></svg><span class="social-count" aria-hidden="true">${formatStars(plugin.stars)}</span></span>`;
   const heart = state.engagementEnabled
     ? pluginHeartButton(plugin, state.engagement[plugin.id], {
         hearted: hasPluginHeart(plugin.id),

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-04";
+} from "./shared.js?v=20260816-05";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -16,7 +16,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-04";
+} from "./shared.js?v=20260816-05";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -24,7 +24,7 @@ import {
   recordEngagementEvent,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260816-04";
+} from "./engagement.js?v=20260816-05";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-04";
+} from "./shared.js?v=20260816-05";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -49,7 +49,7 @@ function engagementMetric(type, count, detail) {
   const views = type === "views";
   const label = views ? "marketplace detail views" : "successful command copies";
   const icon = views
-    ? '<span class="engagement-glyph" aria-hidden="true"></span>'
+    ? '<svg class="engagement-glyph" viewBox="0 0 24 24" aria-hidden="true"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6-9.5-6-9.5-6Z"/><circle cx="12" cy="12" r="2.5"/></svg>'
     : '<span class="copy-icon engagement-copy-icon" aria-hidden="true"></span>';
   const visibleName = views ? "views" : "copies";
   return `<span class="engagement-metric" data-engagement-metric="${type}" title="${label}"><span class="engagement-visual" aria-hidden="true">${icon}<span data-engagement-value>${formatEngagementCount(count)}</span>${detail ? `<span class="engagement-name">${visibleName}</span>` : ""}</span><span class="sr-only" data-engagement-accessible>${count} ${label}</span></span>`;
@@ -74,7 +74,7 @@ export function pluginHeartButton(plugin, stats = {}, {
   const pluginName = escapeHtml(plugin?.name || "plugin");
   const count = engagementCount(stats.hearts);
   const action = hearted ? "Heart sent" : "Send a heart";
-  return `<button class="plugin-heart${detail ? " detail-heart" : ""}${hearted ? " is-hearted" : ""}${pending ? " is-pending" : ""}" type="button" data-plugin-heart="${pluginId}" data-plugin-name="${pluginName}" aria-label="${action} for ${pluginName}; ${count} anonymous hearts" aria-pressed="${hearted}"${pending ? ' aria-busy="true"' : ""}${hearted ? ' aria-disabled="true"' : ""}><span class="social-glyph heart-glyph" data-heart-glyph aria-hidden="true"></span><span class="social-count" data-heart-value aria-hidden="true">${formatEngagementCount(count)}</span></button>`;
+  return `<button class="plugin-heart${detail ? " detail-heart" : ""}${hearted ? " is-hearted" : ""}${pending ? " is-pending" : ""}" type="button" data-plugin-heart="${pluginId}" data-plugin-name="${pluginName}" aria-label="${action} for ${pluginName}; ${count} anonymous hearts" aria-pressed="${hearted}"${pending ? ' aria-busy="true"' : ""}${hearted ? ' aria-disabled="true"' : ""}><svg class="social-glyph heart-glyph" data-heart-glyph viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21 3.5 12.5A5.5 5.5 0 0 1 11.3 4.7L12 5.4l.7-.7a5.5 5.5 0 0 1 7.8 7.8Z"/></svg><span class="social-count" data-heart-value aria-hidden="true">${formatEngagementCount(count)}</span></button>`;
 }
 
 export function hidePendingEngagement(root) {
@@ -101,8 +101,6 @@ export function updatePluginHeart(root, pluginId, stats = {}, {
     if (hearted) button.setAttribute("aria-disabled", "true");
     else button.removeAttribute("aria-disabled");
     button.setAttribute("aria-label", `${hearted ? "Heart sent" : "Send a heart"} for ${button.dataset.pluginName || "plugin"}; ${count} anonymous hearts`);
-    const glyph = button.querySelector("[data-heart-glyph]");
-    if (glyph) glyph.textContent = "";
     const value = button.querySelector("[data-heart-value]");
     if (value) value.textContent = formatEngagementCount(count);
     if (!animate) return;

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260816-04"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-05"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -180,6 +180,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260816-04"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-05"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260816-04"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-05"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-04">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260816-04"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-05"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -595,6 +595,10 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.engagementJs, /https:\/\/api\.omarchyplugins\.com\/v1/);
   assert.match(files.engagementJs, /cache: "no-store",\s*credentials: "omit"/);
   assert.doesNotMatch(files.engagementJs, /Authorization|Bearer|apiKey|apiToken/);
+  assert.match(files.app, /<svg class="social-glyph star-glyph" viewBox="0 0 24 24" aria-hidden="true">/);
+  assert.match(files.sharedJs, /<svg class="engagement-glyph" viewBox="0 0 24 24" aria-hidden="true">/);
+  assert.match(files.sharedJs, /<svg class="social-glyph heart-glyph" data-heart-glyph viewBox="0 0 24 24" aria-hidden="true">/);
+  assert.doesNotMatch(`${files.app}${files.sharedJs}`, /[-]/);
   assert.match(files.app, /data-copy-command="\$\{escapeHtml\(plugin\.installCommand\)\}" data-plugin-id="\$\{escapeHtml\(plugin\.id\)\}"/);
   assert.match(files.app, /if \(!await copyText\(button\.dataset\.copyCommand, button\)\) return;[\s\S]*recordEngagementEvent\(pluginId, "copy"\)/);
   assert.match(files.pluginJs, /recordPluginView\(plugin\.id\)\.then\(applyAuthoritativeEngagement\)/);

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -104,7 +104,7 @@ test("engagement counts and summaries stay compact, accessible, and command-awar
     installCommand: "omarchy plugin add example",
   }, { views: 1200, copies: 4 }, { detail: true });
   assert.match(installable, /data-plugin-engagement="example\.plugin"/);
-  assert.match(installable, /class="engagement-glyph" aria-hidden="true"></);
+  assert.match(installable, /<svg class="engagement-glyph" viewBox="0 0 24 24" aria-hidden="true">[\s\S]*<circle cx="12" cy="12" r="2\.5"\/>/);
   assert.match(installable, /class="copy-icon engagement-copy-icon" aria-hidden="true"><\/span>/);
   assert.match(installable, /data-engagement-accessible>1200 marketplace detail views</);
   assert.match(installable, /data-engagement-accessible>4 successful command copies</);
@@ -120,7 +120,7 @@ test("engagement counts and summaries stay compact, accessible, and command-awar
     hearted: true,
   });
   assert.match(heart, /data-plugin-heart="example\.plugin"/);
-  assert.match(heart, /data-heart-glyph aria-hidden="true"></);
+  assert.match(heart, /<svg class="social-glyph heart-glyph" data-heart-glyph viewBox="0 0 24 24" aria-hidden="true"><path/);
   assert.match(heart, /aria-pressed="true" aria-disabled="true"/);
   assert.doesNotMatch(heart, /\sdisabled/);
   assert.match(heart, />12<\/span>/);


### PR DESCRIPTION
## Summary

- replace Nerd Font private-use glyphs for views, stars, and hearts with portable inline SVGs
- preserve existing colors, sizing, animation, focus behavior, and accessible labels
- refresh the shared asset cache key

## Verification

- `npm test` — 122/122 passed
- mobile browser checks passed at 320, 375, 760, and 1440 px
- mobile card and detail previews inspected at 3× pixel density
- no private-use glyphs remain in `site/`
- final independent review reported 0 actionable findings
