### PR TITLE
Add engagement sorting options

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -3,6 +3,7 @@ import {
   accentColor,
   appendCatalogViewState,
   catalogViewControls,
+  comparePluginEngagement,
   copyText,
   engagementSummary,
   escapeHtml,
@@ -20,14 +21,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-05";
+} from "./shared.js?v=20260816-06";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordEngagementEvent,
   recordPluginHeart,
-} from "./engagement.js?v=20260816-05";
+} from "./engagement.js?v=20260816-06";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -50,7 +51,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260816-05";
+} from "./search.js?v=20260816-06";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
@@ -89,16 +90,23 @@ function cardTaxonomyLabels(plugin) {
   return [cardCategoryNames.get(category) || category, ...specific].filter(Boolean).slice(0, 2);
 }
 
+const engagementSorts = new Set(["views", "copies", "hearts"]);
 const sortOptions = {
   community: [
     ["added", "Recently added"],
     ["updated", "Recent activity"],
     ["stars", "Most starred"],
+    ["views", "Most viewed"],
+    ["copies", "Most copied"],
+    ["hearts", "Most hearts"],
     ["name", "A–Z"]
   ],
   builtin: [
     ["name", "A–Z"],
-    ["kind", "Plugin type"]
+    ["kind", "Plugin type"],
+    ["views", "Most viewed"],
+    ["copies", "Most copied"],
+    ["hearts", "Most hearts"]
   ]
 };
 
@@ -505,6 +513,12 @@ function sourceDefaultSort(source = state.source) {
   return source === "builtin" ? "name" : "added";
 }
 
+function availableSortOptions(source = state.source) {
+  return sortOptions[source].filter(([value]) => (
+    state.engagementEnabled || !engagementSorts.has(value)
+  ));
+}
+
 function allCategoryLabel() {
   return state.source === "builtin" ? "All built-ins" : "All plugins";
 }
@@ -519,6 +533,9 @@ function filteredPlugins() {
     added: (a, b) => listingTime(b) - listingTime(a) || a.name.localeCompare(b.name),
     updated: (a, b) => activityTime(b) - activityTime(a) || a.name.localeCompare(b.name),
     stars: (a, b) => (b.stars || 0) - (a.stars || 0) || a.name.localeCompare(b.name),
+    views: (a, b) => comparePluginEngagement(a, b, state.engagement, "views"),
+    copies: (a, b) => comparePluginEngagement(a, b, state.engagement, "copies"),
+    hearts: (a, b) => comparePluginEngagement(a, b, state.engagement, "hearts"),
     name: (a, b) => a.name.localeCompare(b.name),
     kind: (a, b) => (a.kind || "").localeCompare(b.kind || "") || a.name.localeCompare(b.name)
   };
@@ -533,7 +550,38 @@ function pluginEngagement(plugin) {
   });
 }
 
-function applyAuthoritativeEngagement(pluginId, result) {
+function pluginCardFocusToken(element = document.activeElement) {
+  const card = element?.closest?.("[data-card-plugin]");
+  if (!card || !grid.contains(card)) return null;
+  let control = "details";
+  if (element.matches?.("[data-plugin-heart]")) control = "heart";
+  else if (element.matches?.("[data-copy-command]")) control = "copy";
+  else if (element.matches?.(".plugin-author button")) control = "author";
+  else if (element.matches?.(".builtin-source-action")) control = "source";
+  return { pluginId: card.dataset.cardPlugin, control };
+}
+
+function restorePluginCardFocus(token) {
+  if (!token) return false;
+  const card = [...grid.querySelectorAll("[data-card-plugin]")]
+    .find((candidate) => candidate.dataset.cardPlugin === token.pluginId);
+  if (!card) return false;
+  const selectors = {
+    author: ".plugin-author button",
+    copy: "[data-copy-command]",
+    details: ".plugin-card-link",
+    heart: "[data-plugin-heart]",
+    source: ".builtin-source-action",
+  };
+  const target = card.querySelector(selectors[token.control]) || card.querySelector(".plugin-card-link");
+  target?.focus({ preventScroll: true });
+  return Boolean(target);
+}
+
+function applyAuthoritativeEngagement(pluginId, result, {
+  focusToken = null,
+  sortMetric = "",
+} = {}) {
   if (!result?.recorded || !result.stats) return;
   const current = state.engagementAuthoritative[pluginId]
     || state.engagement[pluginId]
@@ -549,10 +597,15 @@ function applyAuthoritativeEngagement(pluginId, result) {
   updatePluginHeart(document, pluginId, next, {
     hearted: hasPluginHeart(pluginId),
   });
+  if (state.sort === sortMetric) {
+    render();
+    if (!restorePluginCardFocus(focusToken) && focusToken) focusCatalogResult();
+  }
 }
 
 async function heartPlugin(button) {
   if (button.getAttribute("aria-disabled") === "true" || button.dataset.heartSubmitting === "true") return;
+  const focusToken = pluginCardFocusToken(button);
   button.dataset.heartSubmitting = "true";
   button.setAttribute("aria-busy", "true");
   const pluginId = button.dataset.pluginHeart;
@@ -563,7 +616,10 @@ async function heartPlugin(button) {
     showToast("Heart could not be sent. Try again.");
     return;
   }
-  applyAuthoritativeEngagement(pluginId, result);
+  applyAuthoritativeEngagement(pluginId, result, {
+    focusToken,
+    sortMetric: "hearts",
+  });
   updatePluginHeart(document, pluginId, result.stats, {
     animate: true,
     hearted: true,
@@ -572,11 +628,13 @@ async function heartPlugin(button) {
 }
 
 async function copyPluginCommand(button) {
+  const focusToken = pluginCardFocusToken(button);
   if (!await copyText(button.dataset.copyCommand, button)) return;
   const pluginId = button.dataset.pluginId;
   applyAuthoritativeEngagement(
     pluginId,
     await recordEngagementEvent(pluginId, "copy"),
+    { focusToken, sortMetric: "copies" },
   );
 }
 
@@ -624,7 +682,7 @@ function pluginCard(plugin, { showNew = false } = {}) {
     : `<span class="plugin-author">by ${escapeHtml(plugin.author)} · ${escapeHtml(plugin.kind || plugin.category)}</span>`;
 
   return `
-    <article class="plugin-card${plugin.builtIn ? " built-in-card" : ""}" style="--card-accent:${accentColor(plugin.accent)}">
+    <article class="plugin-card${plugin.builtIn ? " built-in-card" : ""}" data-card-plugin="${escapeHtml(plugin.id)}" style="--card-accent:${accentColor(plugin.accent)}">
       <a class="plugin-card-link" href="plugin.html?id=${encodeURIComponent(plugin.id)}" aria-label="View ${escapeHtml(plugin.name)}"></a>
       ${preview}
       <div class="plugin-card-body">
@@ -880,12 +938,11 @@ function renderSourceFilters() {
 }
 
 function renderSortOptions() {
-  sort.innerHTML = sortOptions[state.source]
+  const options = availableSortOptions();
+  sort.innerHTML = options
     .map(([value, label]) => `<option value="${value}">${label}</option>`)
     .join("");
-  if (!sortOptions[state.source].some(([value]) => value === state.sort)) {
-    state.sort = sourceDefaultSort();
-  }
+  if (!options.some(([value]) => value === state.sort)) state.sort = sourceDefaultSort();
   sort.value = state.sort;
 }
 
@@ -956,7 +1013,7 @@ function restoreUrl() {
   state.showAll = viewState.showAll;
   state.page = viewState.page;
   const requestedSort = params.get("sort") || sourceDefaultSort();
-  state.sort = sortOptions[state.source].some(([value]) => value === requestedSort)
+  state.sort = availableSortOptions().some(([value]) => value === requestedSort)
     ? requestedSort
     : sourceDefaultSort();
   search.value = state.query;
@@ -1154,10 +1211,30 @@ async function init() {
             hearted: hasPluginHeart(pluginId),
           });
         });
+        if (engagementSorts.has(state.sort)) {
+          const focusToken = pluginCardFocusToken();
+          render();
+          if (!restorePluginCardFocus(focusToken) && focusToken) focusCatalogResult();
+          const label = availableSortOptions().find(([value]) => value === state.sort)?.[1] || state.sort;
+          catalogResultStatus.textContent = `Engagement loaded. Sorted plugins by ${label.toLowerCase()}.`;
+        }
       }).catch((reason) => {
         console.warn("Engagement stats unavailable", reason);
+        const focusToken = pluginCardFocusToken();
         state.engagementEnabled = false;
         hidePendingEngagement(document);
+        const previousSort = state.sort;
+        const previousLabel = sortOptions[state.source]
+          .find(([value]) => value === previousSort)?.[1] || previousSort;
+        renderSortOptions();
+        if (state.sort !== previousSort) {
+          state.page = 1;
+          render();
+          if (!restorePluginCardFocus(focusToken) && focusToken) focusCatalogResult();
+          const fallbackLabel = availableSortOptions()
+            .find(([value]) => value === state.sort)?.[1] || state.sort;
+          catalogResultStatus.textContent = `${previousLabel} is unavailable because engagement stats could not be loaded. Showing ${fallbackLabel.toLowerCase()}.`;
+        }
       });
     }
   } catch (error) {
@@ -1305,7 +1382,7 @@ async function init() {
     renderSourceFilters();
     renderSortOptions();
     renderCategories();
-    render({ historyMode: "none", announce: true });
+    render({ historyMode: "replace", announce: true });
     if (!restoreCatalogControlFocus(controlFocus) && catalogHadFocus) focusCatalogResult();
   });
 

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-05";
+} from "./shared.js?v=20260816-06";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -16,7 +16,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-05";
+} from "./shared.js?v=20260816-06";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -24,7 +24,7 @@ import {
   recordEngagementEvent,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260816-05";
+} from "./engagement.js?v=20260816-06";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-05";
+} from "./shared.js?v=20260816-06";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -45,6 +45,14 @@ export function formatEngagementCount(value = 0) {
   return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
 }
 
+export function comparePluginEngagement(first, second, stats = {}, metric = "views") {
+  const key = ["views", "copies", "hearts"].includes(metric) ? metric : "views";
+  const value = (plugin) => engagementCount(stats?.[plugin?.id]?.[key]);
+  return value(second) - value(first)
+    || String(first?.name || "").localeCompare(String(second?.name || ""))
+    || String(first?.id || "").localeCompare(String(second?.id || ""));
+}
+
 function engagementMetric(type, count, detail) {
   const views = type === "views";
   const label = views ? "marketplace detail views" : "successful command copies";

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-06">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260816-05"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-06"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260816-06">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -99,6 +99,9 @@
               <option value="added">Recently added</option>
               <option value="updated">Recent activity</option>
               <option value="stars">Most starred</option>
+              <option value="views">Most viewed</option>
+              <option value="copies">Most copied</option>
+              <option value="hearts">Most hearts</option>
               <option value="name">A–Z</option>
             </select>
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 10 4 4 4-4"/></svg>
@@ -180,6 +183,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260816-05"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-06"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-06">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260816-05"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-06"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-05">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-06">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260816-05"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-06"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -619,6 +619,16 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.favicon, /Cable icon geometry from Lucide[\s\S]*Copyright \(c\) 2026 Lucide Icons and Contributors[\s\S]*Permission to use, copy, modify, and\/or distribute[\s\S]*THE SOFTWARE IS PROVIDED "AS IS"/);
   assert.match(files.index, /placeholder="Search plugins, tags, or @authors…"/);
   assert.match(files.index, /<option value="updated">Recent activity<\/option>/);
+  assert.match(files.index, /<option value="stars">Most starred<\/option>[\s\S]*<option value="views">Most viewed<\/option>[\s\S]*<option value="copies">Most copied<\/option>[\s\S]*<option value="hearts">Most hearts<\/option>/);
+  assert.match(files.app, /const engagementSorts = new Set\(\["views", "copies", "hearts"\]\)/);
+  assert.match(files.app, /views: \(a, b\) => comparePluginEngagement\(a, b, state\.engagement, "views"\)/);
+  assert.match(files.app, /copies: \(a, b\) => comparePluginEngagement\(a, b, state\.engagement, "copies"\)/);
+  assert.match(files.app, /hearts: \(a, b\) => comparePluginEngagement\(a, b, state\.engagement, "hearts"\)/);
+  assert.match(files.app, /state\.engagementEnabled = false;[\s\S]*renderSortOptions\(\);[\s\S]*state\.sort !== previousSort/);
+  assert.match(files.app, /data-card-plugin="\$\{escapeHtml\(plugin\.id\)\}"/);
+  assert.match(files.app, /state\.sort === sortMetric[\s\S]*render\(\);[\s\S]*restorePluginCardFocus\(focusToken\)/);
+  assert.match(files.app, /Engagement loaded\. Sorted plugins by/);
+  assert.match(files.app, /is unavailable because engagement stats could not be loaded/);
   assert.match(files.index, /id="search-input"[^>]*role="combobox"[^>]*aria-autocomplete="both"/);
   assert.doesNotMatch(files.index, /id="author-filter"|id="author-select"/);
   assert.match(files.index, /id="search-clear"[^>]*aria-label="Clear all search terms"/);
@@ -887,7 +897,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /viewButton\.addEventListener\("click", \(\) => \{[\s\S]*state\.showAll = true;[\s\S]*resultLinks\[pluginsPerPage\]\?\.focus\(\{ preventScroll: true \}\);[\s\S]*restoreViewScroll\(previousScrollTop\)/);
   assert.match(files.app, /viewDockButton\.addEventListener\("click", \(\) => \{[\s\S]*state\.showAll = false;[\s\S]*focusCatalogResult\(\);[\s\S]*grid\.scrollIntoView/);
   assert.match(files.app, /history\[historyMode === "push" \? "pushState" : "replaceState"\]/);
-  assert.match(files.app, /window\.addEventListener\("popstate", \(\) => \{[\s\S]*const controlFocus = catalogControlFocusToken\(active\);[\s\S]*const catalogHadFocus = Boolean\(controlFocus\)[\s\S]*render\(\{ historyMode: "none", announce: true \}\);[\s\S]*if \(!restoreCatalogControlFocus\(controlFocus\) && catalogHadFocus\) focusCatalogResult\(\)/);
+  assert.match(files.app, /window\.addEventListener\("popstate", \(\) => \{[\s\S]*const controlFocus = catalogControlFocusToken\(active\);[\s\S]*const catalogHadFocus = Boolean\(controlFocus\)[\s\S]*render\(\{ historyMode: "replace", announce: true \}\);[\s\S]*if \(!restoreCatalogControlFocus\(controlFocus\) && catalogHadFocus\) focusCatalogResult\(\)/);
   assert.match(files.app, /const removedAuthorSearch = removedAuthorTerms\.length \|\| removedAuthorDraft;[\s\S]*render\(\{ announce: !removedAuthorSearch \}\);[\s\S]*searchSuggestionStatus\.textContent = searchResultMessage/);
   assert.match(files.app, /firstResult\?\.focus\(\{ preventScroll: true \}\)/);
   assert.match(files.app, /new MutationObserver\(\(\) => \{[\s\S]*updateColors\(\);[\s\S]*if \(reducedMotion\) window\.requestAnimationFrame\(\(now\) => draw\(now\)\)/);

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -12,6 +12,7 @@ import {
   recordPluginView,
 } from "../site/assets/js/engagement.js";
 import {
+  comparePluginEngagement,
   engagementSummary,
   formatEngagementCount,
   formatStars,
@@ -124,6 +125,32 @@ test("engagement counts and summaries stay compact, accessible, and command-awar
   assert.match(heart, /aria-pressed="true" aria-disabled="true"/);
   assert.doesNotMatch(heart, /\sdisabled/);
   assert.match(heart, />12<\/span>/);
+});
+
+test("engagement sort comparators rank counts descending with deterministic ties", () => {
+  const plugins = [
+    { id: "zeta.plugin", name: "Zeta" },
+    { id: "alpha.plugin", name: "Alpha" },
+    { id: "beta.plugin", name: "Beta" },
+  ];
+  const stats = {
+    "alpha.plugin": { views: 10, copies: 1, hearts: 2 },
+    "beta.plugin": { views: 3, copies: 9, hearts: 12 },
+    "zeta.plugin": { views: 10, copies: 9, hearts: 0 },
+  };
+  const orderedIds = (metric) => [...plugins]
+    .sort((first, second) => comparePluginEngagement(first, second, stats, metric))
+    .map((plugin) => plugin.id);
+  assert.deepEqual(orderedIds("views"), ["alpha.plugin", "zeta.plugin", "beta.plugin"]);
+  assert.deepEqual(orderedIds("copies"), ["beta.plugin", "zeta.plugin", "alpha.plugin"]);
+  assert.deepEqual(orderedIds("hearts"), ["beta.plugin", "alpha.plugin", "zeta.plugin"]);
+  assert.deepEqual(orderedIds("unsupported"), orderedIds("views"));
+  assert.equal(comparePluginEngagement(
+    { id: "missing.z", name: "Same" },
+    { id: "missing.a", name: "Same" },
+    { "missing.z": { views: -4 }, "missing.a": { views: Number.NaN } },
+    "views",
+  ) > 0, true);
 });
 
 test("engagement stats accept only safe IDs and non-negative integer counts", () => {


### PR DESCRIPTION
## Summary

- add Most viewed, Most copied, and Most hearts to the marketplace sort dropdown
- support engagement sorting for community and built-in plugins with deterministic ties
- preserve URL, history, pagination, and keyboard focus across asynchronous stats updates
- fall back cleanly when engagement stats are unavailable

## Verification

- `npm test` — 123/123 passed
- browser checks passed for all metrics, deep links, built-ins, and mobile layout
- mutation re-sorting passed after successful heart and copy actions
- delayed success/failure focus, live announcements, and history canonicalization passed
- final independent review reported 0 actionable findings
