### PR TITLE
Polish engagement icon alignment

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -874,8 +874,8 @@ svg {
 .card-stars {
   display: inline-flex; width: 54px; min-width: 54px; height: 25px; padding: 0 4px;
   border: 1px solid var(--line-strong); background: var(--code-bg);
-  align-items: center; justify-content: center; gap: 6px; color: var(--text);
-  font-family: var(--mono); font-size: 11px; line-height: 1;
+  align-items: center; justify-content: center; gap: 4px; color: var(--text);
+  font-family: var(--mono); font-size: 11px; font-weight: 650; line-height: 1;
 }
 .plugin-heart {
   position: relative; display: inline-flex; width: 54px; min-width: 54px; height: 25px; padding: 0 4px;
@@ -911,7 +911,7 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 .engagement-glyph {
   display: inline-grid; width: 13px; height: 13px; color: var(--faint);
   font-family: "Omarchy Engagement Icons"; font-size: 14px; font-weight: 500;
-  line-height: 1; place-items: center;
+  line-height: 1; place-items: center; transform: translateY(-1px);
 }
 .engagement-copy-icon { width: 13px; height: 13px; color: var(--faint); }
 .detail-engagement-cluster {

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -21,14 +21,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-08";
+} from "./shared.js?v=20260816-11";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordEngagementEvent,
   recordPluginHeart,
-} from "./engagement.js?v=20260816-08";
+} from "./engagement.js?v=20260816-11";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -51,7 +51,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260816-08";
+} from "./search.js?v=20260816-11";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-08";
+} from "./shared.js?v=20260816-11";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -16,7 +16,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-08";
+} from "./shared.js?v=20260816-11";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -24,7 +24,7 @@ import {
   recordEngagementEvent,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260816-08";
+} from "./engagement.js?v=20260816-11";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-08";
+} from "./shared.js?v=20260816-11";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-08">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-11">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260816-08"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-11"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260816-08">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260816-11">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -183,6 +183,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260816-08"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-11"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-08">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-11">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260816-08"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-11"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-08">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-11">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260816-08"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-11"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- move the view glyph up by one CSS pixel for optical vertical alignment
- reduce the star-to-count gap while preserving the heart spacing so both appear equally spaced
- match star count weight to the heart count typography
- refresh the shared frontend cache key

## Verification

- `npm test` — 123/123 passed
- desktop DPR 1 and mobile DPR 3 checks passed in dark and light themes
- star and heart count typography match exactly
- view and copy count typography remains identical
- no overflow, console errors, or engagement event writes
- independent final review reported 0 actionable findings
- Worker, D1, API, stats, catalog, registry, bot workflows, plugin IDs, and storage keys are unchanged
