### PR TITLE
Add verification filters to the catalog sort menu

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -13,6 +13,7 @@ import {
   isRecentlyUpdated,
   listingTime,
   loadCatalog,
+  matchesVerificationStatus,
   paginationState,
   pluginHeartButton,
   pluginVerificationState,
@@ -22,14 +23,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-13";
+} from "./shared.js?v=20260816-14";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordEngagementEvent,
   recordPluginHeart,
-} from "./engagement.js?v=20260816-13";
+} from "./engagement.js?v=20260816-14";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -52,7 +53,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260816-13";
+} from "./search.js?v=20260816-14";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
@@ -92,6 +93,7 @@ function cardTaxonomyLabels(plugin) {
 }
 
 const engagementSorts = new Set(["views", "copies", "hearts"]);
+const verificationFilters = new Set(["verified", "unverified"]);
 const sortOptions = {
   community: [
     ["added", "Recently added"],
@@ -100,14 +102,18 @@ const sortOptions = {
     ["views", "Most viewed"],
     ["copies", "Most copied"],
     ["hearts", "Most hearts"],
-    ["name", "A–Z"]
+    ["name", "A–Z"],
+    ["verified", "Verified"],
+    ["unverified", "Unverified"]
   ],
   builtin: [
     ["name", "A–Z"],
     ["kind", "Plugin type"],
     ["views", "Most viewed"],
     ["copies", "Most copied"],
-    ["hearts", "Most hearts"]
+    ["hearts", "Most hearts"],
+    ["verified", "Verified"],
+    ["unverified", "Unverified"]
   ]
 };
 
@@ -527,6 +533,7 @@ function allCategoryLabel() {
 function filteredPlugins() {
   const result = sourcePlugins().filter((plugin) => (
     (state.category === "all" || plugin.category === state.category)
+    && (!verificationFilters.has(state.sort) || matchesVerificationStatus(plugin, state.sort))
     && pluginMatchesActiveSearch(plugin)
   ));
 
@@ -926,7 +933,8 @@ function render({ historyMode = "replace", announce = false } = {}) {
     (plugin) => state.category === "all" || plugin.category === state.category,
   );
   const hasSearch = state.terms.length > 0 || Boolean(state.query.trim());
-  count.textContent = hasSearch
+  const hasResultFilter = hasSearch || verificationFilters.has(state.sort);
+  count.textContent = hasResultFilter
     ? `${visible.length} of ${categoryPlugins.length}`
     : String(categoryPlugins.length);
   countLabel.textContent = state.category === "all"
@@ -1033,6 +1041,10 @@ function resetFilters() {
   search.value = "";
   closeSearchSuggestions();
   renderSearchTerms();
+  if (verificationFilters.has(state.sort)) {
+    state.sort = sourceDefaultSort();
+    renderSortOptions();
+  }
   renderCategories();
   render({ announce: true });
 }

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-13";
+} from "./shared.js?v=20260816-14";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -16,7 +16,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-13";
+} from "./shared.js?v=20260816-14";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -24,7 +24,7 @@ import {
   recordEngagementEvent,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260816-13";
+} from "./engagement.js?v=20260816-14";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-13";
+} from "./shared.js?v=20260816-14";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -190,6 +190,12 @@ export function pluginVersionLabel(plugin) {
   return `manifest ${/^v\d/i.test(version) ? version : `v${version}`}`;
 }
 
+export function matchesVerificationStatus(plugin, status) {
+  return !plugin?.builtIn
+    && plugin?.repositoryLayout !== "suite"
+    && plugin?.verificationStatus === status;
+}
+
 export function pluginVerificationState(plugin) {
   if (plugin?.builtIn) return null;
   if (plugin?.verificationStatus === "verified") {

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260816-13"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-14"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -94,7 +94,7 @@
             <span id="search-suggestion-status" class="sr-only" aria-live="polite"></span>
           </div>
           <label class="sort-control">
-            <span class="sr-only">Sort plugins</span>
+            <span class="sr-only">Sort or filter plugins</span>
             <select id="sort-select">
               <option value="added">Recently added</option>
               <option value="updated">Recent activity</option>
@@ -103,6 +103,8 @@
               <option value="copies">Most copied</option>
               <option value="hearts">Most hearts</option>
               <option value="name">A–Z</option>
+              <option value="verified">Verified</option>
+              <option value="unverified">Unverified</option>
             </select>
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 10 4 4 4-4"/></svg>
           </label>
@@ -183,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260816-13"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-14"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260816-13"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-14"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260816-13"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-14"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -75,6 +75,7 @@ import {
   appendCatalogViewState,
   catalogViewControls,
   findCopyLabel,
+  matchesVerificationStatus,
   pluginVerificationState,
   readCatalogViewState,
   showCopiedState,
@@ -473,6 +474,26 @@ test("plugin verification display copy is minimal and distinguishes third-party 
   assert.equal(pluginVerificationState({ builtIn: true }), null);
 });
 
+test("verification filters match only exact eligible catalog statuses", () => {
+  assert.equal(matchesVerificationStatus({
+    repositoryLayout: "root-plugin",
+    verificationStatus: "verified",
+  }, "verified"), true);
+  assert.equal(matchesVerificationStatus({
+    repositoryLayout: "root-plugin",
+    verificationStatus: "unverified",
+  }, "verified"), false);
+  assert.equal(matchesVerificationStatus({ repositoryLayout: "root-plugin" }, "unverified"), false);
+  assert.equal(matchesVerificationStatus({
+    repositoryLayout: "suite",
+    verificationStatus: "unverified",
+  }, "unverified"), false);
+  assert.equal(matchesVerificationStatus({
+    builtIn: true,
+    verificationStatus: "unverified",
+  }, "unverified"), false);
+});
+
 test("copy feedback targets the visible label instead of a decorative icon", () => {
   const explicitLabel = {};
   const explicitQueries = [];
@@ -584,7 +605,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260816-13");
+  assert.equal(keys[0], "20260816-14");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
@@ -647,6 +668,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.index, /placeholder="Search plugins, tags, or @authors…"/);
   assert.match(files.index, /<option value="updated">Recent activity<\/option>/);
   assert.match(files.index, /<option value="stars">Most starred<\/option>[\s\S]*<option value="views">Most viewed<\/option>[\s\S]*<option value="copies">Most copied<\/option>[\s\S]*<option value="hearts">Most hearts<\/option>/);
+  assert.match(files.index, /<span class="sr-only">Sort or filter plugins<\/span>[\s\S]*<select id="sort-select">[\s\S]*<option value="name">A–Z<\/option>[\s\S]*<option value="verified">Verified<\/option>[\s\S]*<option value="unverified">Unverified<\/option>/);
+  assert.doesNotMatch(files.index, /verification-bar|verification-select/);
   assert.match(files.app, /const engagementSorts = new Set\(\["views", "copies", "hearts"\]\)/);
   assert.match(files.app, /views: \(a, b\) => comparePluginEngagement\(a, b, state\.engagement, "views"\)/);
   assert.match(files.app, /copies: \(a, b\) => comparePluginEngagement\(a, b, state\.engagement, "copies"\)/);
@@ -869,6 +892,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.doesNotMatch(files.app, /function exactPublisher\(value\)|state\.author/);
   assert.match(files.app, /function directPluginMatch\(plugin, value\)/);
   assert.match(files.app, /function pluginMatchesActiveSearch\(plugin\)/);
+  assert.match(files.app, /const verificationFilters = new Set\(\["verified", "unverified"\]\)/);
+  assert.match(files.app, /function filteredPlugins\(\) \{[\s\S]*state\.category === "all"[\s\S]*!verificationFilters\.has\(state\.sort\) \|\| matchesVerificationStatus\(plugin, state\.sort\)[\s\S]*pluginMatchesActiveSearch\(plugin\)/);
+  assert.match(files.sharedJs, /function matchesVerificationStatus\(plugin, status\) \{[\s\S]*!plugin\?\.builtIn[\s\S]*plugin\?\.repositoryLayout !== "suite"[\s\S]*plugin\?\.verificationStatus === status/);
   assert.match(files.searchJs, /function fuzzyScore\(query, candidate\)/);
   assert.match(files.searchJs, /function rankSearchCompletions\(matches\)/);
   assert.match(files.searchJs, /function selectSearchCompletions\(matches, limit = 3\)/);
@@ -889,6 +915,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /class="search-query-summary"/);
   assert.match(files.app, /tabindex="-1" aria-selected="false"/);
   assert.match(files.app, /\$\{visible\.length\} of \$\{categoryPlugins\.length\}/);
+  assert.match(files.app, /const hasResultFilter = hasSearch \|\| verificationFilters\.has\(state\.sort\);[\s\S]*count\.textContent = hasResultFilter/);
   assert.match(files.app, /state\.terms\.some\(\(term\) =>[\s\S]*matchesCommittedSearchTerm\(term, matchContext\)/);
   assert.match(files.app, /typedDraftTerms\.some\(\(term\) =>[\s\S]*matchesDraftSearchTerm\(term, matchContext\)/);
   assert.match(files.app, /return matchesTerm \|\| matchesTextDraft \|\| matchesTypedDraft/);
@@ -896,7 +923,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.doesNotMatch(files.app, /\["Tab", "Enter", "ArrowRight"\]/);
   assert.match(files.app, /data-author=/);
   assert.match(files.app, /appendSearchState\(params, \{ terms: state\.terms, draft: state\.query \}\)/);
+  assert.match(files.app, /if \(state\.sort !== sourceDefaultSort\(\)\) params\.set\("sort", state\.sort\)/);
   assert.match(files.app, /readSearchState\(params\)/);
+  assert.match(files.app, /const requestedSort = params\.get\("sort"\) \|\| sourceDefaultSort\(\);[\s\S]*availableSortOptions\(\)\.some\(\(\[value\]\) => value === requestedSort\)/);
   assert.match(files.app, /const searchTermTypeLabels = \{/);
   assert.match(files.app, /class="search-term-type"/);
   assert.match(files.app, /function commitSearchDraft\(completion\)/);
@@ -924,7 +953,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /viewButton\.addEventListener\("click", \(\) => \{[\s\S]*state\.showAll = true;[\s\S]*resultLinks\[pluginsPerPage\]\?\.focus\(\{ preventScroll: true \}\);[\s\S]*restoreViewScroll\(previousScrollTop\)/);
   assert.match(files.app, /viewDockButton\.addEventListener\("click", \(\) => \{[\s\S]*state\.showAll = false;[\s\S]*focusCatalogResult\(\);[\s\S]*grid\.scrollIntoView/);
   assert.match(files.app, /history\[historyMode === "push" \? "pushState" : "replaceState"\]/);
-  assert.match(files.app, /window\.addEventListener\("popstate", \(\) => \{[\s\S]*const controlFocus = catalogControlFocusToken\(active\);[\s\S]*const catalogHadFocus = Boolean\(controlFocus\)[\s\S]*render\(\{ historyMode: "replace", announce: true \}\);[\s\S]*if \(!restoreCatalogControlFocus\(controlFocus\) && catalogHadFocus\) focusCatalogResult\(\)/);
+  assert.match(files.app, /sort\.addEventListener\("change", \(\) => \{[\s\S]*state\.sort = sort\.value;[\s\S]*state\.page = 1;[\s\S]*render\(\{ announce: true \}\)/);
+  assert.match(files.app, /function resetFilters\(\) \{[\s\S]*verificationFilters\.has\(state\.sort\)[\s\S]*state\.sort = sourceDefaultSort\(\);[\s\S]*renderSortOptions\(\)/);
+  assert.match(files.app, /window\.addEventListener\("popstate", \(\) => \{[\s\S]*const controlFocus = catalogControlFocusToken\(active\);[\s\S]*const catalogHadFocus = Boolean\(controlFocus\)[\s\S]*restoreUrl\(\);[\s\S]*render\(\{ historyMode: "replace", announce: true \}\);[\s\S]*if \(!restoreCatalogControlFocus\(controlFocus\) && catalogHadFocus\) focusCatalogResult\(\)/);
   assert.match(files.app, /const removedAuthorSearch = removedAuthorTerms\.length \|\| removedAuthorDraft;[\s\S]*render\(\{ announce: !removedAuthorSearch \}\);[\s\S]*searchSuggestionStatus\.textContent = searchResultMessage/);
   assert.match(files.app, /firstResult\?\.focus\(\{ preventScroll: true \}\)/);
   assert.match(files.app, /new MutationObserver\(\(\) => \{[\s\S]*updateColors\(\);[\s\S]*if \(reducedMotion\) window\.requestAnimationFrame\(\(now\) => draw\(now\)\)/);


### PR DESCRIPTION
## Summary

- add **Verified** and **Unverified** to the existing catalog sort menu
- filter by exact verification status while excluding built-ins and shell suites
- preserve normal sorting, search, category, pagination, reset, and URL behavior
- keep the existing design unchanged, with no CSS modifications

## Testing

- `npm test` — 148/148 passed
- JavaScript syntax and JSON parsing checks
- `git diff --check`
- headless Chromium checks for filtering, counts, pagination, URL history, reset, themes, and viewports from 320px to 1440px
- independent code review — 0 findings
