### PR TITLE
Add Security Baseline V4 backtest foundation

### DIFF
--- a/test/fixtures/security-baseline-v4/BACKTEST_PLAN.md
+++ b/test/fixtures/security-baseline-v4/BACKTEST_PLAN.md
@@ -1,0 +1,123 @@
+# Security Baseline V3/V4 Offline Backtest Plan
+
+Status: foundation only. This document and the adjacent regression corpus do not add a downloader, V4 policy, scanner rule, work budget, or runnable full-corpus backtest.
+
+## Purpose
+
+Security Baseline V4 must be measured against the current modular V3 implementation before any V4 policy can replace or reinterpret V3. The checked-in corpus provides small, inert characterization inputs for that work. It records current V3 behavior, including known limitations, without defining future V4 outcomes.
+
+The retained material was reviewed against the current architecture. Legacy changes to the former monolithic scanner, marker handling, and workflow matching are not part of this foundation because current `security-baseline-policy.mjs`, `security-baseline-record.mjs`, and architecture tests already own those responsibilities.
+
+## Non-negotiable constraints
+
+- Treat every community repository file as inert bytes. Never import, source, evaluate, spawn, or otherwise execute those bytes.
+- Keep snapshot acquisition separate from offline analysis and require explicit maintainer approval before any live corpus acquisition.
+- Do not require or accept a personal access token.
+- Do not perform a registry-wide or open-submission live backtest as part of ordinary tests.
+- Resolve each source snapshot by normalized repository identity and a full 40-character commit SHA.
+- Give V3 and V4 independent copies of the same verified cached bytes and metadata.
+- Keep snapshot caches and generated comparison results outside published marketplace artifacts and out of Git.
+- Preserve the current V3 policy, records, markers, projection, approval behavior, and outcomes while V4 is being developed.
+
+## Current modular adapter boundary
+
+The V3 offline adapter must call the pure `buildSecurityBaseline` input contract from `security-baseline-analysis.mjs`. It receives only normalized repository identity, repository URL, full commit SHA, and in-memory file records. It must not receive a filesystem path containing community content or a network-capable fetch implementation.
+
+A future V4 adapter must be versioned independently. It must not change the active V3 constants in `security-baseline-policy.mjs`, reinterpret stored V3 records, or route V3 approval and catalog projection through unfinished V4 logic.
+
+The checked-in foundation test deliberately bypasses:
+
+- `security-github-snapshot.mjs` network transport;
+- `security-baseline-scope.mjs` live snapshot resolution;
+- `security-baseline-scanner.mjs` orchestration;
+- `security-baseline.mjs` CLI and filesystem adapter;
+- registry, catalog, approval, verification, and deployment code.
+
+This keeps the fixture contents offline and demonstrates that the corpus characterizes static analysis rather than publication behavior.
+
+## Checked-in regression corpus
+
+`corpus.json` contains bounded, minimal reproductions. Each case includes:
+
+- a stable ID and design classification;
+- coverage labels;
+- issue-derived or synthetic provenance;
+- normalized repository and full commit identity;
+- one or more inert in-memory file records; and
+- the exact current V3 outcome, finding IDs, capability IDs, and approval-blocking result.
+
+Classifications describe V4 design intent without defining policy:
+
+- `candidate-positive` and `candidate-negative` identify proposed detection boundaries;
+- `coverage-decision` identifies behavior that needs an explicit scope decision;
+- `known-v3-false-positive` preserves an existing V3 limitation;
+- `boundary` records a path or syntax edge; and
+- `complexity` records input intended to exercise future bounded analysis.
+
+`expectedV3` is characterization evidence, not a desired V4 result. A known V3 false positive remains recorded as the V3 result so future comparisons explain the delta instead of silently rewriting history. Optional `findingCommentary` is used only when case-specific context adds value beyond the central policy text. Each comment must reference a finding in `expectedV3.findings` and provide distinct submitter and maintainer guidance. Cases without V3 findings cannot carry finding commentary, and generic policy explanations or remediation must not be duplicated here.
+
+## Commit-addressed snapshot cache
+
+A later acquisition tool should use a cache outside the repository by default:
+
+```text
+<cache>/
+  blobs/sha256/<content-sha256>
+  snapshots/<owner>/<repository>/<commit-sha>.json
+  snapshots/<owner>/<repository>/<commit-sha>.json.sha256
+```
+
+Each versioned snapshot manifest should record:
+
+- normalized repository identity;
+- requested full commit SHA and resolved tree SHA;
+- deterministic, path-sorted file entries; and
+- path, Git mode, declared size, binary classification, and content SHA-256.
+
+The adjacent sidecar stores the SHA-256 digest of the exact canonical manifest bytes. A cache hit is valid only after the sidecar, manifest schema, uniqueness constraints, declared limits, and every referenced blob digest are verified. Missing, duplicate, oversized, truncated, or mismatched data is an error, never a partial snapshot.
+
+Acquisition must stage data in a temporary location and mark a cache entry complete only after the complete manifest and all blobs verify. Acquisition is not part of the offline V3/V4 comparison.
+
+## Identical offline inputs
+
+The comparison runner should:
+
+1. load and verify one cached snapshot;
+2. freeze normalized metadata and bytes;
+3. create two independent in-memory copies;
+4. run the versioned V3 and V4 adapters without network access;
+5. record the same snapshot-manifest digest beside both results; and
+6. reject a comparison when the adapters report different input digests.
+
+Neither adapter may mutate shared input or read community content through an unrecorded path.
+
+## Deterministic results and deltas
+
+Write one versioned JSON record per snapshot containing:
+
+- repository, full commit SHA, and snapshot-manifest digest;
+- V3 and V4 adapter status;
+- outcome, finding IDs, and capability IDs for successful adapters;
+- stable error code and stage for failed adapters; and
+- sorted additions, removals, and outcome/error changes.
+
+An adapter error must not include a partial outcome or partial evidence list. Delta arrays must be deduplicated and lexically sorted. Human-readable text may be generated separately but is not a comparison key.
+
+A run-level summary should count unchanged and changed outcomes, added and removed findings, added and removed capabilities, V3-only errors, V4-only errors, and errors shared by both versions.
+
+## Required implementation gates
+
+Future work remains separately approved and should proceed in this order:
+
+1. preserve the checked-in V3 characterization corpus;
+2. define versioned cache and result schemas with tampering tests;
+3. implement the offline loader and V3 adapter without live transport;
+4. test the runner against only the checked-in corpus;
+5. review snapshot acquisition separately before any live request;
+6. acquire an explicitly approved commit-addressed corpus without executing community code;
+7. implement an independent V4 adapter and policy;
+8. backtest the complete listing and submission corpus;
+9. explain every changed outcome and scan error; and
+10. approve migration and enforcement separately.
+
+This foundation does not select V4 findings, define V4 blocking behavior, bump the active baseline version, acquire repository data, or change marketplace publication behavior.

--- a/test/fixtures/security-baseline-v4/corpus.json
+++ b/test/fixtures/security-baseline-v4/corpus.json
@@ -1,0 +1,328 @@
+{
+  "schemaVersion": 1,
+  "description": "Inert offline V3 characterization cases retained for Security Baseline V4 design. File contents are static analysis input and must never be executed.",
+  "characterizedBaselineVersion": "3",
+  "characterizedEnforcementMode": "selective",
+  "cases": [
+    {
+      "id": "issue-146-shared-temp-shell-state",
+      "classification": "candidate-positive",
+      "coverage": ["issue-146", "shell", "shared-temp-state", "fallback", "read-write"],
+      "provenance": {
+        "kind": "issue-derived-minimal-reproduction",
+        "marketplaceIssue": 146,
+        "repository": "tuthan/omarchy-dropdown-terminal",
+        "commitSha": "49e31c4d2c354838a7144c47349f1eb42344e7dd",
+        "sourcePaths": ["bin/omarchy-dropdown-terminal"]
+      },
+      "snapshot": {
+        "repository": "tuthan/omarchy-dropdown-terminal",
+        "commitSha": "49e31c4d2c354838a7144c47349f1eb42344e7dd",
+        "files": [
+          {
+            "path": "bin/omarchy-dropdown-terminal",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\n\nset -u\n\nstate_file=\"${XDG_RUNTIME_DIR:-/tmp}/omarchy-dropdown-terminal.previous-workspace\"\naddress_file=\"${XDG_RUNTIME_DIR:-/tmp}/omarchy-dropdown-terminal.address\"\nterminal_address=\"$(cat \"$address_file\" 2>/dev/null || true)\"\nprintf '%s\\n' \"$terminal_address\" > \"$address_file\"\nprintf '%s\\n' \"$active_workspace\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "issue-122-non-shell-shared-temp-state",
+      "classification": "coverage-decision",
+      "coverage": ["issue-122", "python", "qml", "shared-temp-state", "non-shell"],
+      "provenance": {
+        "kind": "issue-derived-minimal-reproduction",
+        "marketplaceIssue": 122,
+        "repository": "calebhat/omarchy-read-aloud",
+        "commitSha": "5926c6db32cb63e6be662e7dc7e1156c54910e3b",
+        "sourcePaths": ["share/service.py", "chip/Widget.qml"]
+      },
+      "snapshot": {
+        "repository": "calebhat/omarchy-read-aloud",
+        "commitSha": "5926c6db32cb63e6be662e7dc7e1156c54910e3b",
+        "files": [
+          {
+            "path": "share/service.py",
+            "mode": "100644",
+            "content": "import os\nfrom pathlib import Path\n\nRUNTIME = Path(os.environ.get(\"XDG_RUNTIME_DIR\", f\"/tmp/read-aloud-{os.getuid()}\")) / \"read-aloud\"\nSTATE_PATH = RUNTIME / \"state.json\"\nSOCK_PATH = RUNTIME / \"control.sock\"\nPID_PATH = RUNTIME / \"daemon.pid\"\n"
+          },
+          {
+            "path": "chip/Widget.qml",
+            "mode": "100644",
+            "content": "readonly property string runtimeDir: Quickshell.env(\"XDG_RUNTIME_DIR\") || \"/tmp/read-aloud\"\nreadonly property string statePath: runtimeDir + \"/read-aloud/state.json\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "heredoc-command-text-is-not-executed",
+      "classification": "known-v3-false-positive",
+      "coverage": ["heredoc", "false-positive", "quote"],
+      "findingCommentary": [
+        {
+          "ruleId": "curl-pipe-shell",
+          "submitter": "V3 reports this finding because it currently interprets the quoted heredoc body as shell command text, although this minimized case only prints an inert example.",
+          "maintainer": "Confirm that the heredoc is data rather than a generated script that is later executed. This case preserves a known V3 false positive and the required V4 distinction."
+        }
+      ],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000001",
+        "files": [
+          {
+            "path": "bin/render-example",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\ncat <<'EXAMPLE'\ncurl https://example.test/install | sh\nEXAMPLE\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "needs-fixes",
+        "findings": ["curl-pipe-shell"],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "negated-readme-shared-temp-prose",
+      "classification": "candidate-negative",
+      "coverage": ["readme", "negation", "prose"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000002",
+        "files": [
+          {
+            "path": "README.md",
+            "mode": "100644",
+            "content": "# Runtime state\n\nThe plugin does not use shared `/tmp` state. No runtime files are written under `/tmp`.\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "quoted-shared-temp-prose",
+      "classification": "candidate-negative",
+      "coverage": ["shell", "quote", "non-path-argument"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000003",
+        "files": [
+          {
+            "path": "bin/describe-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nprintf '%s\\n' 'example state path: /tmp/example/state.json'\nmessage=\"do not write /tmp/example/state.json\"\nprintf '%s\\n' \"$message\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "quoted-shared-temp-path-write",
+      "classification": "candidate-positive",
+      "coverage": ["shell", "quote", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000004",
+        "files": [
+          {
+            "path": "bin/write-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file='/tmp/example/state.json'\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "control-flow-keeps-shared-temp-possibility",
+      "classification": "candidate-positive",
+      "coverage": ["shell", "control-flow", "branch", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000005",
+        "files": [
+          {
+            "path": "bin/branch-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nif has_private_runtime; then\n  state_file=\"$XDG_RUNTIME_DIR/example/state.json\"\nelse\n  state_file=\"/tmp/example-state.json\"\nfi\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "control-flow-overwrites-shared-temp-path",
+      "classification": "candidate-negative",
+      "coverage": ["shell", "control-flow", "overwrite", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000006",
+        "files": [
+          {
+            "path": "bin/overwrite-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file=\"/tmp/example-state.json\"\nstate_file=\"$XDG_RUNTIME_DIR/example/state.json\"\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "normalized-path-remains-under-shared-tmp",
+      "classification": "candidate-positive",
+      "coverage": ["shell", "path-normalization", "dot-dot", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000007",
+        "files": [
+          {
+            "path": "bin/normalize-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file=\"/tmp/example/../shared-state.json\"\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "normalized-path-escapes-shared-tmp",
+      "classification": "candidate-negative",
+      "coverage": ["shell", "path-normalization", "dot-dot", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000008",
+        "files": [
+          {
+            "path": "bin/normalize-outside",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file=\"/tmp/example/../../home/user/state.json\"\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "var-tmp-is-outside-shared-tmp-scope",
+      "classification": "boundary",
+      "coverage": ["shell", "path-normalization", "prefix-boundary", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "0000000000000000000000000000000000000009",
+        "files": [
+          {
+            "path": "bin/var-tmp-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file=\"/var/tmp/example-state.json\"\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    },
+    {
+      "id": "bounded-control-flow-complexity",
+      "classification": "complexity",
+      "coverage": ["shell", "control-flow", "complexity", "path-write"],
+      "provenance": {
+        "kind": "synthetic-reproduction"
+      },
+      "snapshot": {
+        "repository": "example/security-baseline-v4-corpus",
+        "commitSha": "000000000000000000000000000000000000000a",
+        "files": [
+          {
+            "path": "bin/complex-state",
+            "mode": "100755",
+            "content": "#!/usr/bin/env bash\nstate_file=\"$XDG_RUNTIME_DIR/example/state.json\"\nif first; then state_file=\"/tmp/example-a.json\"; fi\nif second; then state_file=\"/tmp/example-b.json\"; fi\nif third; then state_file=\"$XDG_RUNTIME_DIR/example/c.json\"; fi\nif fourth; then state_file=\"/tmp/example-d.json\"; fi\nprintf '%s\\n' \"$state\" > \"$state_file\"\n"
+          }
+        ]
+      },
+      "expectedV3": {
+        "outcome": "passed",
+        "findings": [],
+        "capabilities": [],
+        "blocksApproval": false
+      }
+    }
+  ]
+}

--- a/test/security-baseline-v4-foundation.test.js
+++ b/test/security-baseline-v4-foundation.test.js
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { buildSecurityBaseline } from "../scripts/security-baseline-analysis.mjs";
+import {
+  securityBaselineBlocksApproval,
+  securityBaselineCapabilityCatalog,
+  securityBaselineEnforcementMode,
+  securityBaselineOutcome,
+  securityBaselineRuleCatalog,
+  securityBaselineVersion,
+} from "../scripts/security-baseline-policy.mjs";
+
+const corpusUrl = new URL("./fixtures/security-baseline-v4/corpus.json", import.meta.url);
+const planUrl = new URL("./fixtures/security-baseline-v4/BACKTEST_PLAN.md", import.meta.url);
+const checkedAt = "2026-08-16T12:00:00.000Z";
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const commitPattern = /^[a-f0-9]{40}$/;
+const caseIdPattern = /^[a-z0-9][a-z0-9-]*$/;
+const classifications = new Set([
+  "boundary",
+  "candidate-negative",
+  "candidate-positive",
+  "complexity",
+  "coverage-decision",
+  "known-v3-false-positive",
+]);
+const expectedCaseIds = Object.freeze([
+  "bounded-control-flow-complexity",
+  "control-flow-keeps-shared-temp-possibility",
+  "control-flow-overwrites-shared-temp-path",
+  "heredoc-command-text-is-not-executed",
+  "issue-122-non-shell-shared-temp-state",
+  "issue-146-shared-temp-shell-state",
+  "negated-readme-shared-temp-prose",
+  "normalized-path-escapes-shared-tmp",
+  "normalized-path-remains-under-shared-tmp",
+  "quoted-shared-temp-path-write",
+  "quoted-shared-temp-prose",
+  "var-tmp-is-outside-shared-tmp-scope",
+]);
+
+function assertExactKeys(value, expected, label) {
+  assert.deepEqual(Object.keys(value).sort(), [...expected].sort(), label);
+}
+
+function assertUniqueStrings(values, label) {
+  assert.ok(Array.isArray(values) && values.length > 0, label);
+  assert.ok(values.every((value) => typeof value === "string" && value.trim() === value && value), label);
+  assert.equal(new Set(values).size, values.length, label);
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+async function readCorpus() {
+  return JSON.parse(await readFile(corpusUrl, "utf8"));
+}
+
+function resultSummary(result) {
+  return {
+    outcome: result.outcome,
+    findings: result.findings.map((finding) => finding.ruleId),
+    capabilities: result.capabilities.map((capability) => capability.id),
+    blocksApproval: result.blocksApproval,
+  };
+}
+
+function validateProvenance(provenance, entry) {
+  assert.equal(typeof provenance, "object", entry.id);
+  if (provenance.kind === "synthetic-reproduction") {
+    assertExactKeys(provenance, ["kind"], `${entry.id} synthetic provenance`);
+    return;
+  }
+  assert.equal(provenance.kind, "issue-derived-minimal-reproduction", entry.id);
+  assertExactKeys(
+    provenance,
+    ["kind", "marketplaceIssue", "repository", "commitSha", "sourcePaths"],
+    `${entry.id} issue provenance`,
+  );
+  assert.ok(Number.isSafeInteger(provenance.marketplaceIssue) && provenance.marketplaceIssue > 0, entry.id);
+  assert.match(provenance.repository, repositoryPattern, entry.id);
+  assert.match(provenance.commitSha, commitPattern, entry.id);
+  assertUniqueStrings(provenance.sourcePaths, `${entry.id} source paths`);
+  assert.equal(provenance.repository, entry.snapshot.repository, entry.id);
+  assert.equal(provenance.commitSha, entry.snapshot.commitSha, entry.id);
+}
+
+function validateFindingCommentary(entry) {
+  const hasCommentary = Object.hasOwn(entry, "findingCommentary");
+  if (!hasCommentary) {
+    assert.notEqual(entry.classification, "known-v3-false-positive", entry.id);
+    return;
+  }
+  assert.ok(entry.expectedV3.findings.length > 0, entry.id);
+  assert.ok(Array.isArray(entry.findingCommentary) && entry.findingCommentary.length > 0, entry.id);
+  const commentaryIds = entry.findingCommentary.map(({ ruleId }) => ruleId);
+  assert.equal(new Set(commentaryIds).size, commentaryIds.length, entry.id);
+  assert.ok(commentaryIds.every((ruleId) => entry.expectedV3.findings.includes(ruleId)), entry.id);
+  for (const commentary of entry.findingCommentary) {
+    assertExactKeys(commentary, ["ruleId", "submitter", "maintainer"], `${entry.id} finding commentary`);
+    assert.ok(Object.hasOwn(securityBaselineRuleCatalog, commentary.ruleId), entry.id);
+    assert.ok(typeof commentary.submitter === "string" && commentary.submitter.length > 20, entry.id);
+    assert.ok(typeof commentary.maintainer === "string" && commentary.maintainer.length > 20, entry.id);
+  }
+}
+
+function validateExpectedV3(expected, entry) {
+  assertExactKeys(
+    expected,
+    ["outcome", "findings", "capabilities", "blocksApproval"],
+    `${entry.id} expected V3`,
+  );
+  assert.ok(["passed", "review-required", "needs-fixes"].includes(expected.outcome), entry.id);
+  assert.ok(Array.isArray(expected.findings), entry.id);
+  assert.ok(Array.isArray(expected.capabilities), entry.id);
+  assert.equal(new Set(expected.findings).size, expected.findings.length, entry.id);
+  assert.equal(new Set(expected.capabilities).size, expected.capabilities.length, entry.id);
+  assert.ok(expected.findings.every((id) => Object.hasOwn(securityBaselineRuleCatalog, id)), entry.id);
+  assert.ok(expected.capabilities.every((id) => Object.hasOwn(securityBaselineCapabilityCatalog, id)), entry.id);
+  assert.equal(expected.outcome, securityBaselineOutcome(expected.findings, expected.capabilities), entry.id);
+  assert.equal(typeof expected.blocksApproval, "boolean", entry.id);
+  assert.equal(securityBaselineBlocksApproval({
+    outcome: expected.outcome,
+    enforcementMode: securityBaselineEnforcementMode,
+    findings: expected.findings,
+    capabilities: expected.capabilities,
+  }), expected.blocksApproval, entry.id);
+}
+
+test("the V4 foundation corpus is inert, bounded, and structurally valid", async () => {
+  const raw = await readFile(corpusUrl, "utf8");
+  assert.ok(Buffer.byteLength(raw) < 128 * 1024);
+  const corpus = JSON.parse(raw);
+  assertExactKeys(
+    corpus,
+    [
+      "schemaVersion",
+      "description",
+      "characterizedBaselineVersion",
+      "characterizedEnforcementMode",
+      "cases",
+    ],
+    "corpus schema",
+  );
+  assert.equal(corpus.schemaVersion, 1);
+  assert.match(corpus.description, /inert offline V3 characterization/i);
+  assert.match(corpus.description, /must never be executed/i);
+  assert.equal(corpus.characterizedBaselineVersion, securityBaselineVersion);
+  assert.equal(corpus.characterizedEnforcementMode, securityBaselineEnforcementMode);
+  assert.ok(Array.isArray(corpus.cases));
+  assert.deepEqual(corpus.cases.map((entry) => entry.id).sort(), [...expectedCaseIds]);
+  assert.equal(new Set(corpus.cases.map((entry) => entry.id)).size, corpus.cases.length);
+
+  for (const entry of corpus.cases) {
+    const expectedEntryKeys = [
+      "id",
+      "classification",
+      "coverage",
+      "provenance",
+      "snapshot",
+      "expectedV3",
+      ...(Object.hasOwn(entry, "findingCommentary") ? ["findingCommentary"] : []),
+    ];
+    assertExactKeys(entry, expectedEntryKeys, `${entry.id || "case"} schema`);
+    assert.match(entry.id, caseIdPattern);
+    assert.ok(classifications.has(entry.classification), entry.id);
+    assertUniqueStrings(entry.coverage, `${entry.id} coverage`);
+    assertExactKeys(entry.snapshot, ["repository", "commitSha", "files"], `${entry.id} snapshot`);
+    assert.match(entry.snapshot.repository, repositoryPattern, entry.id);
+    assert.match(entry.snapshot.commitSha, commitPattern, entry.id);
+    assert.ok(Array.isArray(entry.snapshot.files) && entry.snapshot.files.length > 0, entry.id);
+    assert.ok(entry.snapshot.files.length <= 8, entry.id);
+    assert.ok(
+      entry.snapshot.files.reduce((total, file) => total + Buffer.byteLength(file.content || ""), 0) < 64 * 1024,
+      entry.id,
+    );
+    const paths = new Set();
+    for (const fixtureFile of entry.snapshot.files) {
+      assertExactKeys(fixtureFile, ["path", "mode", "content"], `${entry.id} fixture file`);
+      assert.equal(typeof fixtureFile.path, "string", entry.id);
+      assert.ok(fixtureFile.path && !fixtureFile.path.startsWith("/"), entry.id);
+      assert.ok(!fixtureFile.path.split("/").includes(".."), entry.id);
+      assert.doesNotMatch(fixtureFile.path, /[\\\0]/, entry.id);
+      assert.ok(["100644", "100755"].includes(fixtureFile.mode), entry.id);
+      assert.equal(typeof fixtureFile.content, "string", entry.id);
+      assert.equal(paths.has(fixtureFile.path), false, entry.id);
+      paths.add(fixtureFile.path);
+    }
+    validateProvenance(entry.provenance, entry);
+    validateExpectedV3(entry.expectedV3, entry);
+    validateFindingCommentary(entry);
+  }
+});
+
+test("the V4 foundation corpus preserves current modular V3 outcomes", async () => {
+  const corpus = await readCorpus();
+  for (const entry of corpus.cases) {
+    const files = deepFreeze(structuredClone(entry.snapshot.files));
+    const before = structuredClone(files);
+    const result = buildSecurityBaseline({
+      repository: entry.snapshot.repository,
+      repoUrl: `https://github.com/${entry.snapshot.repository}`,
+      commitSha: entry.snapshot.commitSha,
+      files,
+    }, { checkedAt });
+    assert.deepEqual(resultSummary(result), entry.expectedV3, entry.id);
+    assert.deepEqual(files, before, `${entry.id} input mutation`);
+    assert.equal(result.baselineVersion, securityBaselineVersion, entry.id);
+    assert.equal(result.enforcementMode, securityBaselineEnforcementMode, entry.id);
+  }
+});
+
+test("the V4 offline backtest plan preserves analysis and acquisition boundaries", async () => {
+  const plan = await readFile(planUrl, "utf8");
+  assert.match(plan, /Status: foundation only/);
+  assert.match(plan, /Never import, source, evaluate, spawn, or otherwise execute those bytes/);
+  assert.match(plan, /require explicit maintainer approval before any live corpus acquisition/);
+  assert.match(plan, /pure `buildSecurityBaseline` input contract from `security-baseline-analysis\.mjs`/);
+  assert.match(plan, /must not change the active V3 constants/);
+  assert.match(plan, /independent in-memory copies/);
+  assert.match(plan, /This foundation does not select V4 findings/);
+});


### PR DESCRIPTION
## Summary

- preserve 12 inert Security Baseline regression cases with bounded provenance and exact current V3 expectations
- add schema and characterization tests that call only the pure in-memory baseline analysis
- document the future offline V3/V4 corpus backtest, acquisition boundary, delta review, and activation gates
- retain optional case-specific finding commentary only where it adds distinct submitter and maintainer value

## Security boundaries

- does not add or activate any V4 policy, finding, capability, or enforcement
- does not change production code, workflows, registry data, catalog output, dependencies, or UI
- does not execute fixture content or perform network acquisition during tests
- keeps snapshot acquisition separate from offline analysis and fails closed on invalid corpus data
- manually adapts inert reference evidence without merging or cherry-picking the legacy implementation

## Testing

- `npm test` — 151/151 passed
- JavaScript syntax, JSON parsing, and whitespace checks passed
- independent code review completed with zero findings
