### PR TITLE
Add YT Mini plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5800,6 +5800,22 @@
           "manifestPath": "manifest.json"
         }
       }
+    },
+    {
+      "repo": "https://github.com/joshuaswarren/omarchy-ytmini",
+      "type": "plugin-source",
+      "addedAt": "2026-08-16",
+      "plugins": {
+        "ytmini": {
+          "category": "Widgets",
+          "tags": [
+            "media",
+            "quickshell"
+          ],
+          "accent": "cyan",
+          "initials": "YT"
+        }
+      }
     }
   ],
   "builtInSources": [


### PR DESCRIPTION
## Plugin

**YT Mini** — a floating YouTube window owned by the Omarchy shell itself (pure QML, rendered by QtMultimedia inside `omarchy-shell`; no browser window, no mpv toplevel).

- **Repo:** https://github.com/joshuaswarren/omarchy-ytmini (tag `v0.2.3`)
- **ID:** `io.github.joshuaswarren.ytmini`
- **Kinds:** `panel`, `bar-widget` (`keepLoaded`)
- **Category:** Widgets — **Tags:** media, quickshell
- **License:** MIT; external deps (yt-dlp, wl-clipboard) documented in README
- Handoff: bar-widget clipboard click, `ytmini://` scheme + browser bookmarklet, or `omarchy-shell shell summon` IPC; playlists queue with auto-advance; stream (instant) and grab (1080p local, precise seeking) modes; pauses and hides on session lock; draggable, persisted position.

## Why a direct PR

Issue creation on this repo is currently restricted (REST 404 / GraphQL denial for outside actors, and the web issue form is likewise unavailable), so the documented submission path could not be used. Happy to refile through the regular issue flow if that reopens — the submission body is ready.

## Checklist

- [x] Public repository with manifest.json at the root
- [x] README with install (`omarchy plugin add`) and removal instructions
- [x] License file present; external dependencies documented
- [x] Globally unique ID outside the reserved `omarchy.*` namespace
- [x] preview.png at repo root