### PR TITLE
Fix README tagline punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<p><a href="https://omarchyplugins.com/"><img src="site/assets/img/readme-tagline.png" alt="Browse and discover community plugins for Omarchy at omarchyplugins.com." width="660"></a></p>
+<p><a href="https://omarchyplugins.com/"><img src="site/assets/img/readme-tagline.png" alt="Browse and discover community plugins for Omarchy at omarchyplugins.com" width="660"></a></p>
 
 <a href="https://omarchyplugins.com/develop.html"><img src="site/assets/img/readme-nav/develop.png" alt="Develop" width="104"></a> <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/new?template=submit-plugin.yml"><img src="site/assets/img/readme-nav/submit.png" alt="Submit a Plugin" width="176"></a> <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/new?template=verify-plugin.yml"><img src="site/assets/img/readme-nav/verify.png" alt="Request Automated Plugin Verification" width="340"></a>
 

--- a/test/plugin-verification.test.js
+++ b/test/plugin-verification.test.js
@@ -585,7 +585,7 @@ test("verification issue, workflow, and documentation preserve automatic publica
   assert.match(submissionGuide, new RegExp(requestUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(readme, /<p><a[\s\S]*readme-tagline\.png[\s\S]*<\/a><\/p>/);
   assert.doesNotMatch(readme, /<h1>|readme-header\.png|omarchy-wordmark\.png|<img[^>]+\sheight="/);
-  assert.match(readme, /readme-tagline\.png" alt="Browse and discover community plugins for Omarchy at omarchyplugins\.com\." width="660"/);
+  assert.match(readme, /readme-tagline\.png" alt="Browse and discover community plugins for Omarchy at omarchyplugins\.com" width="660"/);
   assert.match(readme, /readme-nav\/develop\.png[\s\S]*readme-nav\/submit\.png[\s\S]*readme-nav\/verify\.png/);
   assert.doesNotMatch(readme, /readme-nav\/(?:browse|contribute)\.png|<kbd>/);
   assert.match(readme, /issues\/new\?template=submit-plugin\.yml/);


### PR DESCRIPTION
## Summary

- remove the trailing period from the README tagline alt text
- update the exact coupled test expectation

## Verification

- `npm test` — 151/151 passed
- exact-scope check confirms only the requested punctuation and matching expectation changed
- independent final review reported 0 actionable findings
- no workflow, bot, site runtime, Worker, D1, catalog, or statistics changes
