### PR TITLE
Harden anonymous engagement against abuse

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -23,14 +23,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-14";
+} from "./shared.js?v=20260816-15";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
-  recordEngagementEvent,
+  recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260816-14";
+} from "./engagement.js?v=20260816-15";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -53,7 +53,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260816-14";
+} from "./search.js?v=20260816-15";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
@@ -643,7 +643,7 @@ async function copyPluginCommand(button) {
   const pluginId = button.dataset.pluginId;
   applyAuthoritativeEngagement(
     pluginId,
-    await recordEngagementEvent(pluginId, "copy"),
+    await recordPluginCopy(pluginId),
     { focusToken, sortMetric: "copies" },
   );
 }

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-14";
+} from "./shared.js?v=20260816-15";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/engagement.js
+++ b/site/assets/js/engagement.js
@@ -7,7 +7,9 @@ const eventTypes = new Set(["view", "copy", "heart"]);
 const pluginIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const unsafeObjectKeys = new Set(["__proto__", "constructor", "prototype"]);
 const viewStoragePrefix = "omarchy-plugin-view:";
+const copyStoragePrefix = "omarchy-plugin-copy:";
 const heartStoragePrefix = "omarchy-plugin-heart:";
+const copyRequests = new Map();
 const heartRequests = new Map();
 
 function validPluginId(value) {
@@ -133,6 +135,41 @@ export async function recordPluginHeart(pluginId, {
     return await request;
   } finally {
     if (heartRequests.get(pluginId) === request) heartRequests.delete(pluginId);
+  }
+}
+
+export async function recordPluginCopy(pluginId, {
+  storage = globalThis.sessionStorage,
+  ...options
+} = {}) {
+  const baseUrl = engagementApiBaseUrl(options.locationRef || globalThis.location);
+  if (!baseUrl || !validPluginId(String(pluginId || ""))) return null;
+  if (copyRequests.has(pluginId)) return copyRequests.get(pluginId);
+
+  const key = `${copyStoragePrefix}${pluginId}`;
+  try {
+    if (storage?.getItem(key)) return { recorded: false, stats: null };
+    storage?.setItem(key, "1");
+  } catch {
+    // Storage is only a best-effort repeat guard. The event remains anonymous.
+  }
+
+  const request = (async () => {
+    const result = await recordEngagementEvent(pluginId, "copy", options);
+    if (result === null) {
+      try {
+        storage?.removeItem(key);
+      } catch {
+        // A later successful copy may still retry when storage is unavailable.
+      }
+    }
+    return result;
+  })();
+  copyRequests.set(pluginId, request);
+  try {
+    return await request;
+  } finally {
+    if (copyRequests.get(pluginId) === request) copyRequests.delete(pluginId);
   }
 }
 

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -16,15 +16,15 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260816-14";
+} from "./shared.js?v=20260816-15";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
-  recordEngagementEvent,
+  recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260816-14";
+} from "./engagement.js?v=20260816-15";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";
@@ -293,7 +293,7 @@ async function init() {
     copyButton?.addEventListener("click", async () => {
       const command = plugin.builtIn ? plugin.officialCommand : plugin.installCommand;
       if (!await copyText(command, copyButton)) return;
-      applyAuthoritativeEngagement(await recordEngagementEvent(plugin.id, "copy"));
+      applyAuthoritativeEngagement(await recordPluginCopy(plugin.id));
     });
 
     if (engagementEnabled) {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260816-14";
+} from "./shared.js?v=20260816-15";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260816-14"></script>
+    <script type="module" src="assets/js/develop.js?v=20260816-15"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260816-14"></script>
+    <script type="module" src="assets/js/app.js?v=20260816-15"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260816-14"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260816-15"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260816-14"></script>
+    <script type="module" src="assets/js/publish.js?v=20260816-15"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -605,7 +605,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260816-14");
+  assert.equal(keys[0], "20260816-15");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
@@ -648,7 +648,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.engagementFontLicense, /SIL OPEN FONT LICENSE Version 1\.1/);
   assert.match(files.thirdPartyNotices, /JetBrains Mono Nerd Font subset[\s\S]*engagement-icons\.woff2[\s\S]*heart and eye glyphs[\s\S]*engagement-icons\.OFL\.txt/);
   assert.match(files.app, /data-copy-command="\$\{escapeHtml\(plugin\.installCommand\)\}" data-plugin-id="\$\{escapeHtml\(plugin\.id\)\}"/);
-  assert.match(files.app, /if \(!await copyText\(button\.dataset\.copyCommand, button\)\) return;[\s\S]*recordEngagementEvent\(pluginId, "copy"\)/);
+  assert.match(files.app, /if \(!await copyText\(button\.dataset\.copyCommand, button\)\) return;[\s\S]*recordPluginCopy\(pluginId\)/);
+  assert.match(files.pluginJs, /if \(!await copyText\(command, copyButton\)\) return;[\s\S]*recordPluginCopy\(plugin\.id\)/);
+  assert.doesNotMatch(`${files.app}${files.pluginJs}`, /recordEngagementEvent\([^)]*, "copy"\)/);
   assert.match(files.pluginJs, /recordPluginView\(plugin\.id\)\.then\(applyAuthoritativeEngagement\)/);
   assert.match(files.pluginJs, /catch\(\(reason\) => \{[\s\S]*if \(!engagementLoaded\) \{[\s\S]*hidePendingEngagement\(document\)/);
   assert.match(files.pluginJs, /recordPluginHeart\(plugin\.id\)[\s\S]*showToast\("Heart could not be sent\. Try again\."\)[\s\S]*showToast\("Heart sent\."\)/);

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -8,6 +8,7 @@ import {
   loadEngagementStats,
   normalizeEngagementStats,
   recordEngagementEvent,
+  recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
 } from "../site/assets/js/engagement.js";
@@ -85,6 +86,11 @@ function fakeRateLimiter(success = true) {
 
 const productionLocation = { hostname: "omarchyplugins.com" };
 const localLocation = { hostname: "127.0.0.1" };
+const testMinuteLimitVars = {
+  VIEW_MINUTE_EVENT_LIMIT: "2",
+  COPY_MINUTE_EVENT_LIMIT: "2",
+  HEART_MINUTE_EVENT_LIMIT: "2",
+};
 
 test("engagement API routing is explicit and disabled on unrecognized hosts", () => {
   assert.equal(engagementApiBaseUrl(productionLocation), "https://api.omarchyplugins.com/v1");
@@ -212,6 +218,79 @@ test("engagement events contain only the plugin ID and fixed action type", async
     locationRef: productionLocation,
     fetchImpl: async () => { throw new Error("must not run"); },
   }), null);
+});
+
+test("plugin copies are recorded once per browser session and retry after failure", async () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+  let requests = 0;
+  const options = {
+    storage,
+    locationRef: productionLocation,
+    fetchImpl: async () => {
+      requests += 1;
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 5, hearts: 3 },
+      }, { status: 202 });
+    },
+  };
+  assert.deepEqual(await recordPluginCopy("example.plugin", options), {
+    recorded: true,
+    stats: { views: 9, copies: 5, hearts: 3 },
+  });
+  assert.deepEqual(await recordPluginCopy("example.plugin", options), {
+    recorded: false,
+    stats: null,
+  });
+  assert.equal(requests, 1);
+  assert.equal(values.get("omarchy-plugin-copy:example.plugin"), "1");
+
+  const failed = await recordPluginCopy("failed.plugin", {
+    ...options,
+    fetchImpl: async () => {
+      requests += 1;
+      return responseJson({ error: "unavailable" }, { status: 503 });
+    },
+  });
+  assert.equal(failed, null);
+  assert.equal(values.has("omarchy-plugin-copy:failed.plugin"), false);
+});
+
+test("parallel plugin copies share one in-flight request", async () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+  let requests = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const options = {
+    storage,
+    locationRef: productionLocation,
+    fetchImpl: async () => {
+      requests += 1;
+      await gate;
+      return responseJson({
+        recorded: true,
+        plugin: { views: 9, copies: 6, hearts: 3 },
+      }, { status: 202 });
+    },
+  };
+  const first = recordPluginCopy("parallel.plugin", options);
+  const second = recordPluginCopy("parallel.plugin", options);
+  assert.equal(requests, 1);
+  release();
+  assert.deepEqual(await Promise.all([first, second]), [
+    { recorded: true, stats: { views: 9, copies: 6, hearts: 3 } },
+    { recorded: true, stats: { views: 9, copies: 6, hearts: 3 } },
+  ]);
 });
 
 test("plugin views are recorded once per browser session and retry after failure", async () => {
@@ -427,7 +506,80 @@ test("Worker rate limiting runs before request body, catalog, and D1 access", as
   assert.equal(database.calls.length, 0);
 });
 
-test("Worker treats the daily ceiling as a real no-op", async () => {
+test("Worker fails closed when its target limiter is unavailable", async () => {
+  const database = fakeDatabase();
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "copy" }),
+  }), {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    CATALOG_URL: "https://catalog-target-config.example/catalog.json",
+    ...testMinuteLimitVars,
+  }, {
+    fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: "Event service unavailable" });
+  assert.equal(database.calls.length, 0);
+});
+
+test("Worker applies a generic target limiter before D1 access", async () => {
+  const database = fakeDatabase();
+  const outerRateLimiter = fakeRateLimiter();
+  const targetRateLimiter = fakeRateLimiter(false);
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "CF-Connecting-IP": "192.0.2.8",
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "copy" }),
+  }), {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: outerRateLimiter,
+    ENGAGEMENT_TARGET_RATE_LIMITER: targetRateLimiter,
+    CATALOG_URL: "https://catalog-target.example/catalog.json",
+    ...testMinuteLimitVars,
+  }, {
+    fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
+  });
+  assert.equal(response.status, 429);
+  assert.deepEqual(await response.json(), { error: "Rate limit exceeded" });
+  assert.equal(response.headers.get("Retry-After"), "60");
+  assert.deepEqual(outerRateLimiter.keys, ["events:192.0.2.8"]);
+  assert.deepEqual(targetRateLimiter.keys, ["target:192.0.2.8:example.plugin:copy"]);
+  assert.equal(database.calls.length, 0);
+});
+
+test("Worker fails closed when aggregate limit configuration is unavailable", async () => {
+  const database = fakeDatabase();
+  const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "https://omarchyplugins.com",
+    },
+    body: JSON.stringify({ pluginId: "example.plugin", type: "view" }),
+  }), {
+    ENGAGEMENT_DB: database,
+    ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    ENGAGEMENT_TARGET_RATE_LIMITER: fakeRateLimiter(),
+    CATALOG_URL: "https://catalog-config.example/catalog.json",
+  }, {
+    fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
+  });
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: "Event service unavailable" });
+  assert.equal(database.calls.length, 0);
+});
+
+test("Worker treats an aggregate event ceiling as a real no-op", async () => {
   const database = fakeDatabase([], { recorded: null });
   const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
     method: "POST",
@@ -439,12 +591,14 @@ test("Worker treats the daily ceiling as a real no-op", async () => {
   }), {
     ENGAGEMENT_DB: database,
     ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    ENGAGEMENT_TARGET_RATE_LIMITER: fakeRateLimiter(),
     CATALOG_URL: "https://catalog-limit.example/catalog.json",
+    ...testMinuteLimitVars,
   }, {
     fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
   });
   assert.equal(response.status, 202);
-  assert.deepEqual(await response.json(), { recorded: false, reason: "daily-limit" });
+  assert.deepEqual(await response.json(), { recorded: false, reason: "limit" });
   assert.equal(database.calls.length, 2);
   assert.equal(database.calls.every((call) => call.operation === "batch"), true);
 });
@@ -461,7 +615,9 @@ test("Worker returns no success when its transactional write-and-totals batch fa
   }), {
     ENGAGEMENT_DB: database,
     ENGAGEMENT_RATE_LIMITER: fakeRateLimiter(),
+    ENGAGEMENT_TARGET_RATE_LIMITER: fakeRateLimiter(),
     CATALOG_URL: "https://catalog-batch.example/catalog.json",
+    ...testMinuteLimitVars,
   }, {
     fetchImpl: async () => responseJson({ plugins: [{ id: "example.plugin" }] }),
   });
@@ -474,17 +630,39 @@ test("Worker returns no success when its transactional write-and-totals batch fa
 });
 
 test("Worker upserts never lower unrelated counters after a limit reduction", async () => {
-  const migration = await readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8");
+  const [schema, burstMigration] = await Promise.all([
+    readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8"),
+    readFile(new URL("../worker/migrations/0002_plugin_engagement_burst_limits.sql", import.meta.url), "utf8"),
+  ]);
   const database = new DatabaseSync(":memory:");
   try {
-    database.exec(migration);
+    database.exec(schema);
     database.prepare(`
       INSERT INTO plugin_engagement_daily (plugin_id, day, views, copies, hearts)
       VALUES (?1, ?2, ?3, ?4, ?5)
     `).run("example.plugin", "2026-08-16", 10_000, 499, 700);
+    database.exec(burstMigration);
+    const migrated = database.prepare(`
+      SELECT views, copies, hearts,
+        views_minute, views_minute_count,
+        copies_minute, copies_minute_count,
+        hearts_minute, hearts_minute_count
+      FROM plugin_engagement_daily WHERE plugin_id = ?1
+    `).get("example.plugin");
+    assert.deepEqual({ ...migrated }, {
+      views: 10_000,
+      copies: 499,
+      hearts: 700,
+      views_minute: null,
+      views_minute_count: 0,
+      copies_minute: null,
+      copies_minute_count: 0,
+      hearts_minute: null,
+      hearts_minute_count: 0,
+    });
 
     const updated = database.prepare(engagementUpsertStatement())
-      .get("example.plugin", "2026-08-16", 0, 1, 0, 500);
+      .get("example.plugin", "2026-08-16", "2026-08-16T12:00", 0, 1, 0, 500, 10, 10, 10);
     assert.equal(updated.plugin_id, "example.plugin");
     const afterCopy = database.prepare(`
       SELECT views, copies, hearts FROM plugin_engagement_daily WHERE plugin_id = ?1
@@ -492,12 +670,61 @@ test("Worker upserts never lower unrelated counters after a limit reduction", as
     assert.deepEqual({ ...afterCopy }, { views: 10_000, copies: 500, hearts: 700 });
 
     const capped = database.prepare(engagementUpsertStatement())
-      .get("example.plugin", "2026-08-16", 0, 0, 1, 500);
+      .get("example.plugin", "2026-08-16", "2026-08-16T12:00", 0, 0, 1, 500, 10, 10, 10);
     assert.equal(capped, undefined);
     const afterHeart = database.prepare(`
       SELECT views, copies, hearts FROM plugin_engagement_daily WHERE plugin_id = ?1
     `).get("example.plugin");
     assert.deepEqual({ ...afterHeart }, { views: 10_000, copies: 500, hearts: 700 });
+  } finally {
+    database.close();
+  }
+});
+
+test("Worker atomically enforces per-plugin minute ceilings without actor records", async () => {
+  const [schema, burstMigration] = await Promise.all([
+    readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8"),
+    readFile(new URL("../worker/migrations/0002_plugin_engagement_burst_limits.sql", import.meta.url), "utf8"),
+  ]);
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(schema);
+    database.exec(burstMigration);
+    const write = database.prepare(engagementUpsertStatement());
+    const values = (minute, views, copies, hearts) => [
+      "example.plugin", "2026-08-17", minute, views, copies, hearts, 100, 2, 1, 1,
+    ];
+
+    assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)), undefined);
+    assert.equal(write.get(...values("2026-08-17T12:01", 1, 0, 0)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)), undefined);
+    assert.equal(write.get(...values("2026-08-17T12:01", 1, 0, 0)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:01", 1, 0, 0)), undefined);
+    assert.equal(write.get(...values("2026-08-17T12:01", 0, 1, 0)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:01", 0, 1, 0)), undefined);
+    assert.equal(write.get(...values("2026-08-17T12:01", 0, 0, 1)).plugin_id, "example.plugin");
+    assert.equal(write.get(...values("2026-08-17T12:01", 0, 0, 1)), undefined);
+
+    const row = database.prepare(`
+      SELECT views, copies, hearts,
+        views_minute, views_minute_count,
+        copies_minute, copies_minute_count,
+        hearts_minute, hearts_minute_count
+      FROM plugin_engagement_daily WHERE plugin_id = ?1
+    `).get("example.plugin");
+    assert.deepEqual({ ...row }, {
+      views: 4,
+      copies: 1,
+      hearts: 1,
+      views_minute: "2026-08-17T12:01",
+      views_minute_count: 2,
+      copies_minute: "2026-08-17T12:01",
+      copies_minute_count: 1,
+      hearts_minute: "2026-08-17T12:01",
+      hearts_minute_count: 1,
+    });
   } finally {
     database.close();
   }
@@ -538,11 +765,14 @@ test("Worker caches aggregate stats at the edge while disabling browser storage"
 test("Worker records only known catalog plugins from allowed origins", async () => {
   const database = fakeDatabase();
   const rateLimiter = fakeRateLimiter();
+  const targetRateLimiter = fakeRateLimiter();
   const env = {
     ENGAGEMENT_DB: database,
     ENGAGEMENT_RATE_LIMITER: rateLimiter,
+    ENGAGEMENT_TARGET_RATE_LIMITER: targetRateLimiter,
     CATALOG_URL: "https://catalog-one.example/catalog.json",
     DAILY_EVENT_LIMIT: "500",
+    ...testMinuteLimitVars,
   };
   const fetchImpl = async () => responseJson({ plugins: [{ id: "example.plugin" }] });
   const request = (pluginId, origin = "https://omarchyplugins.com", type = "heart") => new Request(
@@ -561,10 +791,13 @@ test("Worker records only known catalog plugins from allowed origins", async () 
     plugin: { views: 9, copies: 4, hearts: 3 },
   });
   assert.equal(database.calls[0].operation, "batch");
-  assert.deepEqual(database.calls[0].values.slice(0, 1), ["example.plugin"]);
-  assert.deepEqual(database.calls[0].values.slice(2), [0, 0, 1, 500]);
+  assert.equal(database.calls[0].values[0], "example.plugin");
+  assert.match(database.calls[0].values[1], /^\d{4}-\d{2}-\d{2}$/);
+  assert.match(database.calls[0].values[2], /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  assert.deepEqual(database.calls[0].values.slice(3), [0, 0, 1, 500, 2, 2, 2]);
   assert.match(database.calls[1].sql, /SELECT SUM\(views\)/);
   assert.match(rateLimiter.keys[0], /^events:/);
+  assert.match(targetRateLimiter.keys[0], /^target:/);
 
   const unknown = await handleRequest(request("unknown.plugin"), env, { fetchImpl });
   assert.equal(unknown.status, 404);
@@ -575,17 +808,33 @@ test("Worker records only known catalog plugins from allowed origins", async () 
 
 test("Worker deployment files contain placeholders but no credentials", async () => {
   const root = new URL("../", import.meta.url);
-  const [ignore, template, migration] = await Promise.all([
+  const [ignore, template, migration, burstMigration, workerSource, clientSource] = await Promise.all([
     readFile(new URL(".gitignore", root), "utf8"),
     readFile(new URL("worker/wrangler.example.jsonc", root), "utf8"),
     readFile(new URL("worker/migrations/0001_plugin_engagement.sql", root), "utf8"),
+    readFile(new URL("worker/migrations/0002_plugin_engagement_burst_limits.sql", root), "utf8"),
+    readFile(new URL("worker/src/index.js", root), "utf8"),
+    readFile(new URL("site/assets/js/engagement.js", root), "utf8"),
   ]);
   assert.match(ignore, /worker\/wrangler\.jsonc/);
   assert.match(ignore, /worker\/\.dev\.vars\*/);
   assert.match(template, /REPLACE_WITH_D1_DATABASE_ID/);
   assert.match(template, /"name": "ENGAGEMENT_RATE_LIMITER"/);
   assert.match(template, /"simple": \{ "limit": 60, "period": 60 \}/);
+  assert.match(template, /"name": "ENGAGEMENT_TARGET_RATE_LIMITER"/);
+  assert.match(template, /REPLACE_WITH_TARGET_RATE_LIMIT/);
+  const configuredTemplate = template.replace('"REPLACE_WITH_TARGET_RATE_LIMIT"', "7");
+  assert.match(configuredTemplate, /"simple": \{ "limit": 7, "period": 60 \}/);
+  assert.doesNotMatch(configuredTemplate, /"limit": "7"/);
+  assert.match(template, /REPLACE_WITH_VIEW_MINUTE_LIMIT/);
+  assert.match(template, /REPLACE_WITH_COPY_MINUTE_LIMIT/);
+  assert.match(template, /REPLACE_WITH_HEART_MINUTE_LIMIT/);
   assert.doesNotMatch(template, /api[_-]?token|account[_-]?token|bearer\s+[A-Za-z0-9]/i);
   assert.match(migration, /hearts INTEGER NOT NULL DEFAULT 0/);
   assert.match(migration, /PRIMARY KEY \(plugin_id, day\)/);
+  assert.match(burstMigration, /ADD COLUMN views_minute TEXT/);
+  assert.match(burstMigration, /ADD COLUMN copies_minute_count INTEGER NOT NULL DEFAULT 0/);
+  assert.match(burstMigration, /ADD COLUMN hearts_minute_count INTEGER NOT NULL DEFAULT 0/);
+  assert.doesNotMatch(burstMigration, /actor|browser|ip_address/i);
+  assert.doesNotMatch(`${workerSource}${clientSource}`, /actorId|actor_hash|omarchy-plugin-actor/i);
 });

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -630,9 +630,10 @@ test("Worker returns no success when its transactional write-and-totals batch fa
 });
 
 test("Worker upserts never lower unrelated counters after a limit reduction", async () => {
-  const [schema, burstMigration] = await Promise.all([
+  const [schema, burstMigration, checkMigration] = await Promise.all([
     readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8"),
     readFile(new URL("../worker/migrations/0002_plugin_engagement_burst_limits.sql", import.meta.url), "utf8"),
+    readFile(new URL("../worker/migrations/0003_fix_engagement_minute_checks.sql", import.meta.url), "utf8"),
   ]);
   const database = new DatabaseSync(":memory:");
   try {
@@ -642,6 +643,7 @@ test("Worker upserts never lower unrelated counters after a limit reduction", as
       VALUES (?1, ?2, ?3, ?4, ?5)
     `).run("example.plugin", "2026-08-16", 10_000, 499, 700);
     database.exec(burstMigration);
+    database.exec(checkMigration);
     const migrated = database.prepare(`
       SELECT views, copies, hearts,
         views_minute, views_minute_count,
@@ -682,20 +684,46 @@ test("Worker upserts never lower unrelated counters after a limit reduction", as
 });
 
 test("Worker atomically enforces per-plugin minute ceilings without actor records", async () => {
-  const [schema, burstMigration] = await Promise.all([
+  const [schema, burstMigration, checkMigration] = await Promise.all([
     readFile(new URL("../worker/migrations/0001_plugin_engagement.sql", import.meta.url), "utf8"),
     readFile(new URL("../worker/migrations/0002_plugin_engagement_burst_limits.sql", import.meta.url), "utf8"),
+    readFile(new URL("../worker/migrations/0003_fix_engagement_minute_checks.sql", import.meta.url), "utf8"),
   ]);
   const database = new DatabaseSync(":memory:");
   try {
     database.exec(schema);
     database.exec(burstMigration);
+    database.exec(checkMigration);
     const write = database.prepare(engagementUpsertStatement());
     const values = (minute, views, copies, hearts) => [
       "example.plugin", "2026-08-17", minute, views, copies, hearts, 100, 2, 1, 1,
     ];
 
     assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)).plugin_id, "example.plugin");
+    const invalidMinutes = [
+      "T026-08-17T12:00",
+      "2026-0T-17T12:00",
+      "2026-08-T7T12:00",
+      "2026-08-17T1-:00",
+      "2026-08-17T12:0T",
+      "2026/08-17T12:00",
+      "2026-08/17T12:00",
+      "2026-08-17 12:00",
+      "2026-08-17T12-00",
+      "2026-08-17T12:0",
+      "2026-08-17T12:000",
+    ];
+    for (const column of ["views_minute", "copies_minute", "hearts_minute"]) {
+      const updateMinute = database.prepare(`
+        UPDATE plugin_engagement_daily SET ${column} = ?1 WHERE plugin_id = ?2
+      `);
+      for (const invalidMinute of invalidMinutes) {
+        assert.throws(
+          () => updateMinute.run(invalidMinute, "example.plugin"),
+          /CHECK constraint failed/,
+        );
+      }
+    }
     assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)).plugin_id, "example.plugin");
     assert.equal(write.get(...values("2026-08-17T12:00", 1, 0, 0)), undefined);
     assert.equal(write.get(...values("2026-08-17T12:01", 1, 0, 0)).plugin_id, "example.plugin");
@@ -808,11 +836,12 @@ test("Worker records only known catalog plugins from allowed origins", async () 
 
 test("Worker deployment files contain placeholders but no credentials", async () => {
   const root = new URL("../", import.meta.url);
-  const [ignore, template, migration, burstMigration, workerSource, clientSource] = await Promise.all([
+  const [ignore, template, migration, burstMigration, checkMigration, workerSource, clientSource] = await Promise.all([
     readFile(new URL(".gitignore", root), "utf8"),
     readFile(new URL("worker/wrangler.example.jsonc", root), "utf8"),
     readFile(new URL("worker/migrations/0001_plugin_engagement.sql", root), "utf8"),
     readFile(new URL("worker/migrations/0002_plugin_engagement_burst_limits.sql", root), "utf8"),
+    readFile(new URL("worker/migrations/0003_fix_engagement_minute_checks.sql", root), "utf8"),
     readFile(new URL("worker/src/index.js", root), "utf8"),
     readFile(new URL("site/assets/js/engagement.js", root), "utf8"),
   ]);
@@ -836,5 +865,10 @@ test("Worker deployment files contain placeholders but no credentials", async ()
   assert.match(burstMigration, /ADD COLUMN copies_minute_count INTEGER NOT NULL DEFAULT 0/);
   assert.match(burstMigration, /ADD COLUMN hearts_minute_count INTEGER NOT NULL DEFAULT 0/);
   assert.doesNotMatch(burstMigration, /actor|browser|ip_address/i);
+  assert.match(checkMigration, /DROP COLUMN views_minute/);
+  assert.match(checkMigration, /substr\(views_minute, 11, 1\) = 'T'/);
+  assert.match(checkMigration, /substr\(views_minute, 1, 4\) NOT GLOB '\*\[\^0-9\]\*'/);
+  assert.match(checkMigration, /substr\(hearts_minute, 15, 2\) NOT GLOB '\*\[\^0-9\]\*'/);
+  assert.doesNotMatch(checkMigration, /actor|browser|ip_address/i);
   assert.doesNotMatch(`${workerSource}${clientSource}`, /actorId|actor_hash|omarchy-plugin-actor/i);
 });

--- a/worker/README.md
+++ b/worker/README.md
@@ -3,19 +3,20 @@
 This Cloudflare Worker stores anonymous aggregate marketplace engagement in D1.
 It records three actions:
 
-- `view`: a successfully rendered plugin detail page, guarded once per browser session
-- `copy`: a successful plugin command copy action
-- `heart`: an anonymous positive reaction, guarded once per plugin in local browser storage
+- `view`: a successfully rendered plugin detail page with a best-effort repeat guard
+- `copy`: a successful plugin command copy action with a best-effort repeat guard
+- `heart`: an anonymous positive reaction with a best-effort repeat guard
 
 These values describe marketplace activity. They are not downloads, installations,
 unique people, verified votes, quality signals, or security signals.
 
 ## Privacy and trust boundary
 
-The application does not send or store accounts, cookies, IP addresses, user-agent
-strings, command text, repository URLs, or plugin metadata. Event bodies contain only
-a catalog plugin ID and the fixed action type. Cloudflare still processes normal request
-metadata as the network provider under the account's Cloudflare configuration.
+The application does not persist accounts, cookies, browser identifiers, IP addresses,
+user-agent strings, command text, repository URLs, or plugin metadata in D1 or application
+tables. Event bodies contain only a catalog plugin ID and the fixed action type. D1 stores
+anonymous plugin-level aggregates only. Cloudflare processes normal request metadata and
+uses the request IP only for ephemeral abuse controls under the account's configuration.
 
 The public API contains no credentials. D1 is available only through the Worker binding.
 Keep the real `wrangler.jsonc`, `.dev.vars`, local Wrangler state, and all credentials out
@@ -24,8 +25,10 @@ of version control.
 ## Local configuration
 
 Copy `wrangler.example.jsonc` to the ignored `wrangler.jsonc`, create the D1 database,
-and replace only the local `REPLACE_WITH_D1_DATABASE_ID` value. Apply the migration
-before starting the Worker on `127.0.0.1:8787`.
+and replace every `REPLACE_WITH_...` placeholder with the matching local identifier or
+positive limit. Replace the quoted rate-limit placeholder, including its quotes, with a
+positive JSON integer. Apply all migrations before starting the Worker on
+`127.0.0.1:8787`.
 
 The production custom-domain route is intentionally commented out in the template.
 Verify a workers.dev deployment before adding `api.omarchyplugins.com` to the local
@@ -38,14 +41,13 @@ configuration.
   `{ "pluginId": "...", "type": "copy" }`, or
   `{ "pluginId": "...", "type": "heart" }` from an allowed marketplace origin.
 
-The Worker validates plugin IDs against the published marketplace catalog, applies a
-Cloudflare edge rate limit before catalog or D1 access, and enforces a daily ceiling per
-plugin and event type. The rate limiter uses the request IP as an ephemeral Cloudflare
-edge key; the application does not write that key to D1. Public stats are cached at the
-edge for up to five minutes, while browser storage is disabled and successful event
-responses return authoritative fresh counts for immediate UI feedback.
+The Worker validates plugin IDs against the published marketplace catalog and applies
+best-effort abuse controls before accepting an event. It never writes request-derived
+limit keys to D1. Public stats are cached at the edge for up to five minutes, while browser
+storage is disabled and successful event responses return authoritative fresh counts for
+immediate UI feedback.
 
-Anonymous public counters remain inherently susceptible to manipulation. Local browser
-storage is only a best-effort repeat guard and can be cleared or bypassed. Hearts must be
-presented as anonymous reactions, never as unique or verified votes, trust, or quality
-rankings.
+Anonymous public counters remain inherently susceptible to slow or distributed
+manipulation. Browser guards and rate limits are best-effort controls that can be cleared,
+distributed, or bypassed. Hearts must be presented as anonymous reactions, never as
+unique or verified votes, trust, or quality rankings.

--- a/worker/migrations/0002_plugin_engagement_burst_limits.sql
+++ b/worker/migrations/0002_plugin_engagement_burst_limits.sql
@@ -1,0 +1,32 @@
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN views_minute TEXT CHECK (
+    views_minute IS NULL OR (
+      length(views_minute) = 16
+      AND views_minute GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN views_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (views_minute_count >= 0);
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN copies_minute TEXT CHECK (
+    copies_minute IS NULL OR (
+      length(copies_minute) = 16
+      AND copies_minute GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN copies_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (copies_minute_count >= 0);
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN hearts_minute TEXT CHECK (
+    hearts_minute IS NULL OR (
+      length(hearts_minute) = 16
+      AND hearts_minute GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN hearts_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (hearts_minute_count >= 0);

--- a/worker/migrations/0003_fix_engagement_minute_checks.sql
+++ b/worker/migrations/0003_fix_engagement_minute_checks.sql
@@ -1,0 +1,63 @@
+ALTER TABLE plugin_engagement_daily DROP COLUMN views_minute;
+ALTER TABLE plugin_engagement_daily DROP COLUMN views_minute_count;
+ALTER TABLE plugin_engagement_daily DROP COLUMN copies_minute;
+ALTER TABLE plugin_engagement_daily DROP COLUMN copies_minute_count;
+ALTER TABLE plugin_engagement_daily DROP COLUMN hearts_minute;
+ALTER TABLE plugin_engagement_daily DROP COLUMN hearts_minute_count;
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN views_minute TEXT CHECK (
+    views_minute IS NULL OR (
+      length(views_minute) = 16
+      AND substr(views_minute, 5, 1) = '-'
+      AND substr(views_minute, 8, 1) = '-'
+      AND substr(views_minute, 11, 1) = 'T'
+      AND substr(views_minute, 14, 1) = ':'
+      AND substr(views_minute, 1, 4) NOT GLOB '*[^0-9]*'
+      AND substr(views_minute, 6, 2) NOT GLOB '*[^0-9]*'
+      AND substr(views_minute, 9, 2) NOT GLOB '*[^0-9]*'
+      AND substr(views_minute, 12, 2) NOT GLOB '*[^0-9]*'
+      AND substr(views_minute, 15, 2) NOT GLOB '*[^0-9]*'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN views_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (views_minute_count >= 0);
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN copies_minute TEXT CHECK (
+    copies_minute IS NULL OR (
+      length(copies_minute) = 16
+      AND substr(copies_minute, 5, 1) = '-'
+      AND substr(copies_minute, 8, 1) = '-'
+      AND substr(copies_minute, 11, 1) = 'T'
+      AND substr(copies_minute, 14, 1) = ':'
+      AND substr(copies_minute, 1, 4) NOT GLOB '*[^0-9]*'
+      AND substr(copies_minute, 6, 2) NOT GLOB '*[^0-9]*'
+      AND substr(copies_minute, 9, 2) NOT GLOB '*[^0-9]*'
+      AND substr(copies_minute, 12, 2) NOT GLOB '*[^0-9]*'
+      AND substr(copies_minute, 15, 2) NOT GLOB '*[^0-9]*'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN copies_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (copies_minute_count >= 0);
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN hearts_minute TEXT CHECK (
+    hearts_minute IS NULL OR (
+      length(hearts_minute) = 16
+      AND substr(hearts_minute, 5, 1) = '-'
+      AND substr(hearts_minute, 8, 1) = '-'
+      AND substr(hearts_minute, 11, 1) = 'T'
+      AND substr(hearts_minute, 14, 1) = ':'
+      AND substr(hearts_minute, 1, 4) NOT GLOB '*[^0-9]*'
+      AND substr(hearts_minute, 6, 2) NOT GLOB '*[^0-9]*'
+      AND substr(hearts_minute, 9, 2) NOT GLOB '*[^0-9]*'
+      AND substr(hearts_minute, 12, 2) NOT GLOB '*[^0-9]*'
+      AND substr(hearts_minute, 15, 2) NOT GLOB '*[^0-9]*'
+    )
+  );
+
+ALTER TABLE plugin_engagement_daily
+  ADD COLUMN hearts_minute_count INTEGER NOT NULL DEFAULT 0 CHECK (hearts_minute_count >= 0);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -39,11 +39,28 @@ function json(payload, status = 200, headers = {}) {
   });
 }
 
-function eventLimit(value) {
+function boundedEventLimit(value, fallback) {
   const limit = Math.trunc(Number(value));
   return Number.isSafeInteger(limit) && limit > 0
     ? Math.min(limit, 1_000_000)
-    : defaultDailyEventLimit;
+    : fallback;
+}
+
+function eventLimit(value) {
+  return boundedEventLimit(value, defaultDailyEventLimit);
+}
+
+function configuredEventLimit(value) {
+  return boundedEventLimit(value, 0);
+}
+
+function minuteEventLimits(env) {
+  const limits = {
+    views: configuredEventLimit(env.VIEW_MINUTE_EVENT_LIMIT),
+    copies: configuredEventLimit(env.COPY_MINUTE_EVENT_LIMIT),
+    hearts: configuredEventLimit(env.HEART_MINUTE_EVENT_LIMIT),
+  };
+  return Object.values(limits).every(Boolean) ? limits : null;
 }
 
 function validCatalogUrl(value) {
@@ -187,22 +204,68 @@ async function readLimitedBody(request, limit) {
 }
 
 const engagementUpsertSql = `
-  INSERT INTO plugin_engagement_daily (plugin_id, day, views, copies, hearts)
-  VALUES (?1, ?2, ?3, ?4, ?5)
+  INSERT INTO plugin_engagement_daily (
+    plugin_id, day, views, copies, hearts,
+    views_minute, views_minute_count,
+    copies_minute, copies_minute_count,
+    hearts_minute, hearts_minute_count
+  )
+  VALUES (
+    ?1, ?2, ?4, ?5, ?6,
+    CASE WHEN ?4 > 0 THEN ?3 ELSE NULL END, ?4,
+    CASE WHEN ?5 > 0 THEN ?3 ELSE NULL END, ?5,
+    CASE WHEN ?6 > 0 THEN ?3 ELSE NULL END, ?6
+  )
   ON CONFLICT(plugin_id, day) DO UPDATE SET
     views = CASE WHEN excluded.views > 0
-      THEN MIN(plugin_engagement_daily.views + excluded.views, ?6)
+      THEN MIN(plugin_engagement_daily.views + excluded.views, ?7)
       ELSE plugin_engagement_daily.views END,
     copies = CASE WHEN excluded.copies > 0
-      THEN MIN(plugin_engagement_daily.copies + excluded.copies, ?6)
+      THEN MIN(plugin_engagement_daily.copies + excluded.copies, ?7)
       ELSE plugin_engagement_daily.copies END,
     hearts = CASE WHEN excluded.hearts > 0
-      THEN MIN(plugin_engagement_daily.hearts + excluded.hearts, ?6)
-      ELSE plugin_engagement_daily.hearts END
+      THEN MIN(plugin_engagement_daily.hearts + excluded.hearts, ?7)
+      ELSE plugin_engagement_daily.hearts END,
+    views_minute = CASE WHEN excluded.views > 0
+      THEN ?3 ELSE plugin_engagement_daily.views_minute END,
+    views_minute_count = CASE WHEN excluded.views > 0
+      THEN CASE WHEN plugin_engagement_daily.views_minute = ?3
+        THEN plugin_engagement_daily.views_minute_count + excluded.views
+        ELSE excluded.views END
+      ELSE plugin_engagement_daily.views_minute_count END,
+    copies_minute = CASE WHEN excluded.copies > 0
+      THEN ?3 ELSE plugin_engagement_daily.copies_minute END,
+    copies_minute_count = CASE WHEN excluded.copies > 0
+      THEN CASE WHEN plugin_engagement_daily.copies_minute = ?3
+        THEN plugin_engagement_daily.copies_minute_count + excluded.copies
+        ELSE excluded.copies END
+      ELSE plugin_engagement_daily.copies_minute_count END,
+    hearts_minute = CASE WHEN excluded.hearts > 0
+      THEN ?3 ELSE plugin_engagement_daily.hearts_minute END,
+    hearts_minute_count = CASE WHEN excluded.hearts > 0
+      THEN CASE WHEN plugin_engagement_daily.hearts_minute = ?3
+        THEN plugin_engagement_daily.hearts_minute_count + excluded.hearts
+        ELSE excluded.hearts END
+      ELSE plugin_engagement_daily.hearts_minute_count END
   WHERE
-    (excluded.views > 0 AND plugin_engagement_daily.views < ?6)
-    OR (excluded.copies > 0 AND plugin_engagement_daily.copies < ?6)
-    OR (excluded.hearts > 0 AND plugin_engagement_daily.hearts < ?6)
+    (excluded.views > 0
+      AND plugin_engagement_daily.views < ?7
+      AND (plugin_engagement_daily.views_minute IS NULL
+        OR plugin_engagement_daily.views_minute < ?3
+        OR (plugin_engagement_daily.views_minute = ?3
+          AND plugin_engagement_daily.views_minute_count < ?8)))
+    OR (excluded.copies > 0
+      AND plugin_engagement_daily.copies < ?7
+      AND (plugin_engagement_daily.copies_minute IS NULL
+        OR plugin_engagement_daily.copies_minute < ?3
+        OR (plugin_engagement_daily.copies_minute = ?3
+          AND plugin_engagement_daily.copies_minute_count < ?9)))
+    OR (excluded.hearts > 0
+      AND plugin_engagement_daily.hearts < ?7
+      AND (plugin_engagement_daily.hearts_minute IS NULL
+        OR plugin_engagement_daily.hearts_minute < ?3
+        OR (plugin_engagement_daily.hearts_minute = ?3
+          AND plugin_engagement_daily.hearts_minute_count < ?10)))
   RETURNING plugin_id
 `;
 
@@ -224,8 +287,8 @@ async function eventResponse(request, env, origin, fetchImpl) {
   if (!env.ENGAGEMENT_RATE_LIMITER?.limit) {
     return json({ error: "Rate limiter unavailable" }, 503, corsHeaders(origin));
   }
-  const actor = request.headers.get("CF-Connecting-IP") || "unknown";
-  const rateLimit = await env.ENGAGEMENT_RATE_LIMITER.limit({ key: `events:${actor}` });
+  const requestIp = request.headers.get("CF-Connecting-IP") || "unknown";
+  const rateLimit = await env.ENGAGEMENT_RATE_LIMITER.limit({ key: `events:${requestIp}` });
   if (!rateLimit.success) {
     return json(
       { error: "Rate limit exceeded" },
@@ -256,19 +319,49 @@ async function eventResponse(request, env, origin, fetchImpl) {
     return json({ error: "Unknown plugin" }, 404, corsHeaders(origin));
   }
 
-  const day = new Date().toISOString().slice(0, 10);
+  if (!env.ENGAGEMENT_TARGET_RATE_LIMITER?.limit) {
+    return json({ error: "Event service unavailable" }, 503, corsHeaders(origin));
+  }
+  const targetRateLimit = await env.ENGAGEMENT_TARGET_RATE_LIMITER.limit({
+    key: `target:${requestIp}:${event.pluginId}:${event.type}`,
+  });
+  if (!targetRateLimit.success) {
+    return json(
+      { error: "Rate limit exceeded" },
+      429,
+      { ...corsHeaders(origin), "Retry-After": "60" },
+    );
+  }
+
+  const timestamp = new Date().toISOString();
+  const day = timestamp.slice(0, 10);
+  const minute = timestamp.slice(0, 16);
   const views = event.type === "view" ? 1 : 0;
   const copies = event.type === "copy" ? 1 : 0;
   const hearts = event.type === "heart" ? 1 : 0;
   const limit = eventLimit(env.DAILY_EVENT_LIMIT);
+  const minuteLimits = minuteEventLimits(env);
+  if (!minuteLimits) {
+    return json({ error: "Event service unavailable" }, 503, corsHeaders(origin));
+  }
   const [writeResult, totalsResult] = await env.ENGAGEMENT_DB.batch([
-    env.ENGAGEMENT_DB.prepare(engagementUpsertSql)
-      .bind(event.pluginId, day, views, copies, hearts, limit),
+    env.ENGAGEMENT_DB.prepare(engagementUpsertSql).bind(
+      event.pluginId,
+      day,
+      minute,
+      views,
+      copies,
+      hearts,
+      limit,
+      minuteLimits.views,
+      minuteLimits.copies,
+      minuteLimits.hearts,
+    ),
     env.ENGAGEMENT_DB.prepare(engagementTotalsSql).bind(event.pluginId),
   ]);
 
   if (!writeResult?.results?.length) {
-    return json({ recorded: false, reason: "daily-limit" }, 202, corsHeaders(origin));
+    return json({ recorded: false, reason: "limit" }, 202, corsHeaders(origin));
   }
   return json({
     recorded: true,

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -6,7 +6,10 @@
   "workers_dev": true,
   "vars": {
     "CATALOG_URL": "https://omarchyplugins.com/catalog.json",
-    "DAILY_EVENT_LIMIT": "10000"
+    "DAILY_EVENT_LIMIT": "10000",
+    "VIEW_MINUTE_EVENT_LIMIT": "REPLACE_WITH_VIEW_MINUTE_LIMIT",
+    "COPY_MINUTE_EVENT_LIMIT": "REPLACE_WITH_COPY_MINUTE_LIMIT",
+    "HEART_MINUTE_EVENT_LIMIT": "REPLACE_WITH_HEART_MINUTE_LIMIT"
   },
   "d1_databases": [
     {
@@ -21,6 +24,12 @@
       "name": "ENGAGEMENT_RATE_LIMITER",
       "namespace_id": "1001",
       "simple": { "limit": 60, "period": 60 }
+    },
+    {
+      "name": "ENGAGEMENT_TARGET_RATE_LIMITER",
+      "namespace_id": "1002",
+      // Replace the quoted placeholder, including its quotes, with a positive JSON integer.
+      "simple": { "limit": "REPLACE_WITH_TARGET_RATE_LIMIT", "period": 60 }
     }
   ],
 


### PR DESCRIPTION
## Summary

- add best-effort repeat protection for successful command-copy engagement
- add layered anonymous abuse controls without accounts or persistent browser identifiers
- preserve aggregate-only D1 storage and existing public metric semantics

## Privacy

- no actor IDs, cookies, fingerprints, accounts, or IP persistence in D1
- event bodies remain limited to `pluginId` and `type`
- production thresholds remain outside version control

## Verification

- `npm test` — 157/157 passed
- existing D1 totals survive the migration in local SQLite coverage
- delayed requests cannot reset newer aggregate windows
- isolated browser checks cover repeat copy, reload, and a fresh mobile session
- root README, catalog, workflows, CSS, fonts, and engagement icons are unchanged
- independent final review reported 0 actionable findings

No Cloudflare migration or deployment has been performed from this branch.
