### PR TITLE
Fix verifier issue reporting

### DIFF
--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -364,6 +364,7 @@ jobs:
       - name: Publish verification result
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RESULT: ${{ needs.analyze.outputs.result }}
           EXPECTED_TITLE: ${{ github.event.issue.title }}
@@ -432,6 +433,7 @@ jobs:
       - name: Report verification workflow failure
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/test/plugin-verification.test.js
+++ b/test/plugin-verification.test.js
@@ -572,6 +572,12 @@ test("verification issue, workflow, and documentation preserve automatic publica
   assert.match(publishJob, /main changed after the tested verification; refusing to rebase/);
   assert.match(workflow, /git ls-remote[\s\S]*refusing to deploy an older verification artifact/);
   assert.match(workflow, /<!-- marketplace-plugin-verification -->/);
+  const reportJob = workflow.slice(workflow.indexOf("\n  report:\n"), workflow.indexOf("\n  report-failure:\n"));
+  const reportFailureJob = workflow.slice(workflow.indexOf("\n  report-failure:\n"));
+  for (const source of [reportJob, reportFailureJob]) {
+    assert.match(source, /GH_REPO: \$\{\{ github\.repository \}\}/);
+    assert.doesNotMatch(source, /actions\/checkout/);
+  }
   assert.doesNotMatch(workflow, /personal access token|\bPAT\b/);
 
   for (const document of [guide, policy]) {


### PR DESCRIPTION
## Summary

- set `GH_REPO` for the checkout-free verification reporting jobs
- allow `gh issue comment` and `gh issue close` to resolve the marketplace repository
- add regression coverage for both reporting jobs while preserving least-privilege behavior

## Testing

- `npm test` — 157 passed
- `node --test test/plugin-verification.test.js` — 12 passed
- verified read-only `gh issue` repository resolution outside a Git checkout with `GH_REPO`

Closes #438
