### PR TITLE
Polish responsive plugin metadata

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -201,7 +201,7 @@ svg {
 }
 [data-theme="light"] .page-header h1 { color: var(--text); }
 .page-meta {
-  display: flex; margin-top: 10px; align-items: center; gap: 15px; color: var(--text);
+  display: flex; margin-top: 10px; align-items: center; flex-wrap: wrap; gap: 15px; color: var(--text);
   font-family: var(--mono); font-size: 11px; font-weight: 500; letter-spacing: .01em;
 }
 .page-meta, .aside-meta, .card-stars, .catalog-heading p,
@@ -209,9 +209,23 @@ svg {
   font-variant-numeric: tabular-nums;
 }
 .page-meta > span + span::before { margin-right: 15px; color: var(--faint); content: "|"; }
-.page-meta .manifest-version { min-width: 0; overflow-wrap: anywhere; }
+.plugin-detail-article .page-meta { column-gap: 37px; }
+.plugin-detail-article .page-meta > span { position: relative; }
+.plugin-detail-article .page-meta > span + span::before {
+  position: absolute; right: calc(100% + 15px); margin-right: 0;
+}
+.plugin-detail-article .page-meta > .is-line-start::before { display: none; }
+.page-meta .manifest-version { min-width: 0; max-width: 100%; flex: none; }
+.page-meta .manifest-version > span {
+  display: block; max-width: 100%; overflow: hidden; overflow-wrap: normal;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.detail-status-meta { display: inline-flex; align-items: center; }
 .page-meta .card-verification { margin-left: 0; }
-.page-meta > .detail-verification::before { margin-right: 8px; }
+.page-meta .detail-status-meta > .detail-verification { margin-left: 15px; }
+.page-meta .detail-status-meta > .detail-verification::before {
+  margin-right: 8px; color: var(--faint); content: "|";
+}
 .status { display: inline-flex; align-items: center; color: var(--stable); text-transform: uppercase; }
 .status-dot {
   display: inline-block; width: 8px; height: 8px; margin-right: 7px; border-radius: 50%;
@@ -394,6 +408,13 @@ svg {
 .aside-meta .status-label.is-unverified {
   border-color: color-mix(in srgb, var(--accent) 72%, var(--line));
   color: var(--accent);
+}
+.aside-meta .aside-verification { margin-left: 0; }
+.aside-meta .aside-verification .card-verification-trigger {
+  min-width: 0; height: auto; background: transparent;
+}
+.aside-meta .aside-verification .card-verification-tooltip {
+  width: min(220px, calc(100vw - 56px)); text-align: left;
 }
 
 /* Detail and publishing content */
@@ -936,7 +957,7 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 }
 .card-activity-state {
   display: flex; width: max-content; height: 21px; padding: 0 7px;
-  border: 0; border-left: 2px solid currentColor; background: var(--code-bg);
+  border: 0; background: var(--code-bg);
   align-items: center; color: var(--stable); font-family: var(--mono); font-size: 10px;
   font-weight: 700; letter-spacing: .04em; line-height: 11px; text-transform: uppercase;
   white-space: nowrap;
@@ -1120,6 +1141,9 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 }
 [data-theme="light"] .footer-disclaimer { color: var(--muted); }
 
+@media (min-width: 1101px) {
+  .plugin-detail-article .page-meta > .detail-status-meta { display: none; }
+}
 @media (max-width: 1100px) {
   .app-shell { grid-template-columns: var(--sidebar) minmax(0, 1fr); }
   .right-aside { display: none; }
@@ -1147,6 +1171,7 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   .page-content { width: auto; padding: 25px 18px calc(92px + env(safe-area-inset-bottom)); }
   .page-header h1 { font-size: 28px; }
   .page-meta { flex-wrap: wrap; gap: 8px 12px; }
+  .plugin-detail-article .page-meta { column-gap: 12px; }
   .page-meta span + span::before { display: none; }
   .intro { font-size: 15px; }
   .plugin-card {

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,14 +24,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-17";
+} from "./shared.js?v=20260817-18";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260817-17";
+} from "./engagement.js?v=20260817-18";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -54,7 +54,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260817-17";
+} from "./search.js?v=20260817-18";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-17";
+} from "./shared.js?v=20260817-18";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -19,7 +19,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-17";
+} from "./shared.js?v=20260817-18";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -27,7 +27,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260817-17";
+} from "./engagement.js?v=20260817-18";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";
@@ -45,6 +45,13 @@ function detailVerificationBadge(plugin) {
     <button class="card-verification-trigger" type="button" data-verification-tooltip aria-expanded="false" aria-label="${escapeHtml(`${verification.label}. ${verification.explanation}`)}">
       <span class="card-verification-marker">${escapeHtml(verification.label)}</span>
     </button>
+    <span class="card-verification-tooltip" role="tooltip" aria-hidden="true">${escapeHtml(verification.explanation)}</span>
+  </span>`;
+}
+
+function asideVerificationBadge(verification) {
+  return `<span class="card-verification aside-verification is-${verification.status}">
+    <button class="card-verification-trigger status-label is-${verification.status}" type="button" data-verification-tooltip aria-expanded="false" aria-label="${escapeHtml(`${verification.label}. ${verification.explanation}`)}">${escapeHtml(verification.label)}</button>
     <span class="card-verification-tooltip" role="tooltip" aria-hidden="true">${escapeHtml(verification.explanation)}</span>
   </span>`;
 }
@@ -93,6 +100,27 @@ function bindDetailVerificationTooltip(root) {
   documentRef.defaultView?.addEventListener("resize", () => {
     if (container?.matches(":hover, :focus-within") || container?.classList.contains("is-open")) position();
   });
+}
+
+function setupDetailMetaLineStarts(root) {
+  const meta = root.querySelector(".page-meta");
+  if (!meta) return;
+  const update = () => {
+    let lineCenter = null;
+    [...meta.children].forEach((item) => {
+      item.classList.remove("is-line-start");
+      if (getComputedStyle(item).display === "none") return;
+      const rect = item.getBoundingClientRect();
+      const center = (rect.top + rect.bottom) / 2;
+      if (lineCenter === null || Math.abs(center - lineCenter) > 2) {
+        item.classList.add("is-line-start");
+        lineCenter = center;
+      }
+    });
+  };
+  update();
+  root.ownerDocument.fonts?.ready.then(update);
+  root.ownerDocument.defaultView?.addEventListener("resize", update);
 }
 
 function detailTemplate(plugin, engagement, {
@@ -185,7 +213,7 @@ function detailTemplate(plugin, engagement, {
     : "";
   const versionLabel = pluginVersionLabel(plugin);
   const manifestVersion = versionLabel
-    ? `<span class="manifest-version">${escapeHtml(versionLabel)}</span>`
+    ? `<span class="manifest-version"><span>${escapeHtml(versionLabel)}</span></span>`
     : "";
   const verificationBadge = detailVerificationBadge(plugin);
 
@@ -193,7 +221,7 @@ function detailTemplate(plugin, engagement, {
     <article class="plugin-detail-article" style="--card-accent:${accentColor(plugin.accent)}">
       <header class="page-header" id="overview"><div class="page-eyebrow">${escapeHtml(plugin.category)}</div>
         <div class="detail-title"><span class="detail-icon">${escapeHtml(plugin.initials)}</span><h1>${escapeHtml(plugin.name)}</h1></div>
-        <div class="page-meta"><span>${escapeHtml(plugin.id)}</span>${manifestVersion}<span>by ${escapeHtml(plugin.author)}</span><span class="status ${statusTone(plugin)}"><i class="status-dot" aria-hidden="true"></i>${escapeHtml(plugin.status || "Available")}</span>${verificationBadge}</div>
+        <div class="page-meta"><span>${escapeHtml(plugin.id)}</span>${manifestVersion}<span>by ${escapeHtml(plugin.author)}</span><span class="detail-status-meta"><span class="status ${statusTone(plugin)}"><i class="status-dot" aria-hidden="true"></i>${escapeHtml(plugin.status || "Available")}</span>${verificationBadge}</span></div>
         ${engagementEnabled ? `<div class="detail-engagement-cluster">
           ${engagementSummary(plugin, engagement, { detail: true, pending: pendingEngagement })}
           ${pluginHeartButton(plugin, engagement, { detail: true, hearted, pending: pendingEngagement })}
@@ -267,6 +295,7 @@ async function init() {
     });
     bindDetailVerificationTooltip(content);
     setupControlTooltips(content);
+    setupDetailMetaLineStarts(content);
     if (currentHashId() === "trust") {
       const url = new URL(location.href);
       url.hash = "terms";
@@ -305,7 +334,8 @@ async function init() {
     const verificationRow = document.querySelector("#aside-verification-row");
     verificationRow.hidden = !verification;
     if (verification) {
-      document.querySelector("#aside-verification").innerHTML = `<span class="status-label is-${verification.status}">${escapeHtml(verification.label)}</span>`;
+      document.querySelector("#aside-verification").innerHTML = asideVerificationBadge(verification);
+      bindDetailVerificationTooltip(verificationRow);
     }
     const versionLabel = pluginVersionLabel(plugin);
     document.querySelector("#aside-version").textContent = versionLabel

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-17";
+} from "./shared.js?v=20260817-18";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-14">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-16">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260817-17"></script>
+    <script type="module" src="assets/js/develop.js?v=20260817-18"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260816-14">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260816-16">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260817-17"></script>
+    <script type="module" src="assets/js/app.js?v=20260817-18"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-14">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-16">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260817-17"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260817-18"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-14">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260816-16">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260817-17"></script>
+    <script type="module" src="assets/js/publish.js?v=20260817-18"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -613,12 +613,12 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260817-17");
+  assert.equal(keys[0], "20260817-18");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
   assert.equal(new Set(styleKeys).size, 1);
-  assert.equal(styleKeys[0], "20260816-14");
+  assert.equal(styleKeys[0], "20260816-16");
   const faviconKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/favicon\.svg\?v=([^"']+)/)?.[1]);
   assert.ok(faviconKeys.every(Boolean));
@@ -978,9 +978,10 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.plugin, /<dt>Availability<\/dt><dd id="aside-status">—<\/dd>/);
   assert.match(files.plugin, /id="aside-verification-row"><dt>Verification<\/dt><dd id="aside-verification">—<\/dd>/);
   assert.match(files.pluginJs, /const verificationBadge = detailVerificationBadge\(plugin\)/);
-  assert.match(files.pluginJs, /\$\{verificationBadge\}<\/div>/);
+  assert.match(files.pluginJs, /class="detail-status-meta">[\s\S]*\$\{verificationBadge\}<\/span><\/div>/);
   assert.match(files.pluginJs, /verificationRow\.hidden = !verification/);
-  assert.match(files.pluginJs, /class="status-label is-\$\{verification\.status\}"/);
+  assert.match(files.pluginJs, /function asideVerificationBadge\(verification\)[\s\S]*data-verification-tooltip aria-expanded="false" aria-label=/);
+  assert.match(files.pluginJs, /innerHTML = asideVerificationBadge\(verification\);\s*bindDetailVerificationTooltip\(verificationRow\);/);
   assert.doesNotMatch(files.publishJs, /left-sidebar \.sidebar-link\[href\^='#'\]/);
   assert.match(files.publishJs, /markerRatio: 0\.25,[\s\S]*markerMax: 160,[\s\S]*activateLastAtPageEnd: true/);
   assert.match(files.publish, /href="#overview" data-section-ids="overview requirements">Guide<\/a>/);
@@ -1000,7 +1001,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.plugin-card-body \.plugin-description \{[\s\S]*max-height: 21px;[\s\S]*text-overflow: clip; white-space: nowrap;[\s\S]*mask-image: linear-gradient/);
   assert.match(styles, /\.plugin-card-body \.plugin-description \{[\s\S]*margin: 4px 0 9px;/);
   assert.match(styles, /\.card-status-line \{[\s\S]*justify-content: space-between;/);
-  assert.match(styles, /\.card-activity-state \{[\s\S]*border-left: 2px solid currentColor;[\s\S]*font-size: 10px;/);
+  assert.match(styles, /\.card-activity-state \{[^}]*border: 0;[^}]*font-size: 10px;/);
+  assert.doesNotMatch(styles, /\.card-activity-state \{[^}]*border-left:/);
   assert.match(styles, /\.card-verification-trigger \{[\s\S]*min-width: 24px; height: 24px;[\s\S]*text-transform: none;/);
   assert.match(styles, /\.card-verification-marker \{[\s\S]*height: 21px;[\s\S]*background: var\(--code-bg\);/);
   assert.doesNotMatch(styles, /\.card-verification-marker \{[^}]*border-right:/);
@@ -1015,7 +1017,27 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.plugin-card:has\(\.has-control-tooltip:hover\),[\s\S]*overflow: visible;/);
   assert.match(styles, /\.control-tooltip \{[\s\S]*right: 0;[\s\S]*bottom: calc\(100% \+ 8px\); left: auto;/);
   assert.match(styles, /\.plugin-card-actions \{[\s\S]*position: relative; z-index: 3;/);
-  assert.match(styles, /\.page-meta > \.detail-verification::before \{ margin-right: 8px; \}/);
+  const basePageMetaRule = styles.match(/\.page-meta\s*\{([^}]*)\}/)?.[1] || "";
+  assert.match(basePageMetaRule, /flex-wrap: wrap;/);
+  assert.match(styles, /\.page-meta \.manifest-version \{ min-width: 0; max-width: 100%; flex: none; \}/);
+  assert.match(styles, /\.page-meta \.manifest-version > span\s*\{[^}]*max-width: 100%;[^}]*overflow: hidden;[^}]*overflow-wrap: normal;[^}]*text-overflow: ellipsis;[^}]*white-space: nowrap;/);
+  assert.match(files.pluginJs, /class="manifest-version"><span>\$\{escapeHtml\(versionLabel\)\}<\/span><\/span>/);
+  assert.match(styles, /\.plugin-detail-article \.page-meta \{ column-gap: 37px; \}/);
+  assert.match(styles, /\.plugin-detail-article \.page-meta > span \{ position: relative; \}/);
+  assert.match(styles, /\.plugin-detail-article \.page-meta > span \+ span::before\s*\{[^}]*position: absolute; right: calc\(100% \+ 15px\); margin-right: 0;/);
+  assert.match(styles, /\.plugin-detail-article \.page-meta > \.is-line-start::before \{ display: none; \}/);
+  assert.match(styles, /@media \(max-width: 760px\) \{[\s\S]*\.plugin-detail-article \.page-meta \{ column-gap: 12px; \}/);
+  assert.match(styles, /\.page-meta \.detail-status-meta > \.detail-verification \{ margin-left: 15px; \}/);
+  assert.match(styles, /\.page-meta \.detail-status-meta > \.detail-verification::before\s*\{[^}]*margin-right: 8px;[^}]*content: "\|";/);
+  assert.match(styles, /\.aside-meta \.aside-verification \.card-verification-tooltip\s*\{[^}]*width: min\(220px, calc\(100vw - 56px\)\); text-align: left;/);
+  const wideDetailStatusStart = styles.indexOf("@media (min-width: 1101px)");
+  const narrowDetailStatusStart = styles.indexOf("@media (max-width: 1100px)");
+  assert.ok(wideDetailStatusStart >= 0 && narrowDetailStatusStart > wideDetailStatusStart);
+  const wideDetailStatusMedia = styles.slice(wideDetailStatusStart, narrowDetailStatusStart);
+  assert.match(wideDetailStatusMedia, /\.plugin-detail-article \.page-meta > \.detail-status-meta \{ display: none; \}/);
+  const nextResponsiveMedia = styles.indexOf("@media", narrowDetailStatusStart + 1);
+  const narrowDetailStatusMedia = styles.slice(narrowDetailStatusStart, nextResponsiveMedia);
+  assert.match(narrowDetailStatusMedia, /\.right-aside \{ display: none; \}/);
   assert.match(styles, /\.card-verification:hover:not\(\.is-dismissed\) \.card-verification-tooltip,[\s\S]*\.card-verification:focus-within:not\(\.is-dismissed\) \.card-verification-tooltip,[\s\S]*\.card-verification\.is-open \.card-verification-tooltip/);
   assert.match(files.app, /class="card-status-line">\$\{activityState\}\$\{verificationState\}/);
   assert.doesNotMatch(files.app, /verification-check|✓/);
@@ -1030,7 +1052,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(sharedJs, /event\.key !== "Escape"[\s\S]*classList\.add\("is-tooltip-dismissed"\)/);
   assert.match(sharedJs, /defaultView\?\.addEventListener\("resize"[\s\S]*forEach\(positionControlTooltip\)/);
   assert.match(files.app, /function bindCardActions\(root\) \{\s*setupControlTooltips\(root\);/);
-  assert.match(files.pluginJs, /bindDetailVerificationTooltip\(content\);\s*setupControlTooltips\(content\);/);
+  assert.match(files.pluginJs, /bindDetailVerificationTooltip\(content\);\s*setupControlTooltips\(content\);\s*setupDetailMetaLineStarts\(content\);/);
+  assert.match(files.pluginJs, /function setupDetailMetaLineStarts\(root\)[\s\S]*classList\.remove\("is-line-start"\)[\s\S]*Math\.abs\(center - lineCenter\) > 2[\s\S]*classList\.add\("is-line-start"\)[\s\S]*addEventListener\("resize", update\)/);
   assert.match(files.pluginJs, /event\.key === "Escape"[\s\S]*container\?\.matches\(":hover, :focus-within"\)[\s\S]*close\(\)/);
   assert.match(files.pluginJs, /const open = \(\) => \{[\s\S]*classList\.remove\("is-dismissed"\);[\s\S]*position\(\);/);
   assert.match(files.pluginJs, /defaultView\?\.addEventListener\("resize"[\s\S]*position\(\)/);
@@ -1045,7 +1068,6 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.card-stars \{[\s\S]*width: 54px;[\s\S]*height: 25px;/);
   assert.match(styles, /\.plugin-card-actions \.engagement-metric \{[\s\S]*height: 25px;/);
   assert.match(styles, /\.plugin-heart\.is-celebrating \.heart-glyph \{[\s\S]*animation: heart-confirm 220ms/);
-  assert.match(styles, /\.page-meta \.manifest-version \{ min-width: 0; overflow-wrap: anywhere; \}/);
   assert.match(styles, /\.plugin-card-link:focus-visible \{ outline-offset: -2px; \}/);
   assert.match(styles, /\.page-header::before \{[\s\S]*linear-gradient\(90deg, transparent, var\(--line\) 12%, var\(--line\) 88%, transparent\)/);
   assert.doesNotMatch(styles, /\.page-header::after/);


### PR DESCRIPTION
 ```markdown                                                                                                                                                                    
   ## Summary                                                                                                                                                                   
                                                                                                                                                                                
   - keep manifest version labels horizontal and ellipsize maximum-length values instead of allowing vertical character wrapping or page overflow                               
   - wrap detail metadata as complete items while preserving same-line separators and suppressing separators at actual line starts                                              
   - show availability and verification in the desktop metadata aside, while retaining them in the header when the aside is hidden at narrower widths                           
   - preserve the full accessible verification explanation through the themed aside tooltip                                                                                     
   - remove the leading edge from both `New` and `Updated` activity badges without changing their colors, typography, or six-hour window                                        
                                                                                                                                                                                
   ## Testing                                                                                                                                                                   
                                                                                                                                                                                
   - `npm test` — 160/160 passing                                                                                                                                               
   - `git diff --check origin/main`                                                                                                                                             
   - dark/light Chromium checks across desktop, tablet, and mobile breakpoints                                                                                                  
   - verified header/aside switching, maximum-length manifest ellipsis, metadata separators, no horizontal overflow, and tooltip accessibility                                  
 ``` 