### PR TITLE
Extend activity badges to 12 hours

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,14 +24,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-18";
+} from "./shared.js?v=20260817-19";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260817-18";
+} from "./engagement.js?v=20260817-19";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -54,7 +54,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260817-18";
+} from "./search.js?v=20260817-19";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-18";
+} from "./shared.js?v=20260817-19";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -19,7 +19,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-18";
+} from "./shared.js?v=20260817-19";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -27,7 +27,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260817-18";
+} from "./engagement.js?v=20260817-19";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-18";
+} from "./shared.js?v=20260817-19";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -237,7 +237,7 @@ export function currentHashId() {
   }
 }
 
-export function isRecentlyAdded(plugin, now = Date.now(), windowHours = 6) {
+export function isRecentlyAdded(plugin, now = Date.now(), windowHours = 12) {
   if (plugin?.builtIn || plugin?.placeholder) return false;
   const listedAt = listingTime(plugin);
   if (!Number.isFinite(listedAt)) return false;
@@ -245,7 +245,7 @@ export function isRecentlyAdded(plugin, now = Date.now(), windowHours = 6) {
   return age >= 0 && age < windowHours * 60 * 60 * 1000;
 }
 
-export function isRecentlyUpdated(plugin, now = Date.now(), windowHours = 6) {
+export function isRecentlyUpdated(plugin, now = Date.now(), windowHours = 12) {
   if (!plugin?.versionUpdatedAt || plugin?.builtIn || plugin?.placeholder) return false;
   const updatedAt = Date.parse(plugin.versionUpdatedAt);
   if (!Number.isFinite(updatedAt)) return false;

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260817-18"></script>
+    <script type="module" src="assets/js/develop.js?v=20260817-19"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260817-18"></script>
+    <script type="module" src="assets/js/app.js?v=20260817-19"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260817-18"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260817-19"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260817-18"></script>
+    <script type="module" src="assets/js/publish.js?v=20260817-19"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -613,7 +613,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260817-18");
+  assert.equal(keys[0], "20260817-19");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -358,10 +358,10 @@ test("root plugins default to Quattro while curated exceptions use manual setup"
   assert.equal(lacuna?.installAvailable, false);
 });
 
-test("recently added badges use a 6-hour listing window", () => {
+test("recently added badges use a 12-hour listing window", () => {
   const now = Date.parse("2026-07-28T12:00:00Z");
-  assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T06:00:00.001Z" }, now), true);
-  assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T06:00:00.000Z" }, now), false);
+  assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T00:00:00.001Z" }, now), true);
+  assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T00:00:00.000Z" }, now), false);
   assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T12:00:00.001Z" }, now), false);
   assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T11:00:00.000Z", placeholder: true }, now), false);
   assert.equal(isRecentlyAdded({ listedAt: "2026-07-28T11:00:00.000Z", builtIn: true }, now), false);
@@ -394,7 +394,7 @@ test("recent activity uses the newest valid plugin timestamp", () => {
   );
 });
 
-test("manifest version changes create a six-hour updated state", () => {
+test("manifest version changes create a 12-hour updated state", () => {
   const detectedAt = "2026-07-28T12:00:00.000Z";
   const plugins = [
     { id: "new-plugin", version: "1.0.0" },
@@ -420,14 +420,14 @@ test("manifest version changes create a six-hour updated state", () => {
   assert.equal(
     isRecentlyUpdated(
       result.find((plugin) => plugin.id === "updated-plugin"),
-      Date.parse("2026-07-28T17:59:59.999Z"),
+      Date.parse("2026-07-28T23:59:59.999Z"),
     ),
     true,
   );
   assert.equal(
     isRecentlyUpdated(
       result.find((plugin) => plugin.id === "updated-plugin"),
-      Date.parse("2026-07-28T18:00:00.000Z"),
+      Date.parse("2026-07-29T00:00:00.000Z"),
     ),
     false,
   );


### PR DESCRIPTION
## Summary

- keep `New` and `Updated` activity badges visible for 12 hours instead of 6
- update the exact boundary coverage for both activity states
- bump the coupled JavaScript cache key

## Testing

- `npm test` — 161/161 passing
- `git diff --check origin/main..HEAD`