### PR TITLE
Exclude reverse-DNS host namespace from plugin ID search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ Check these invariants:
 
 Run `npm run dev` for local runtime review. The server listens on `http://127.0.0.1:4173`. Stop the server after the review unless the maintainer asks to keep it running.
 
+## Catalog search
+
+Free-text search indexes plugin names, descriptions, authors, publishers, categories, kinds, and tags. Plugin IDs are indexed without their reverse-DNS host namespace, because most listings use `io.github.<user>.<name>` and indexing that prefix made every one of them match unrelated queries such as `github`. Queries that contain a dot still match the complete ID, and typed `plugin:` terms continue to compare against the full ID.
+
 ## Accessibility and interaction
 
 Use semantic HTML and native controls. Preserve the skip link, landmark structure, visible focus indicators, keyboard navigation, accessible names, live status messages, and reduced-motion behavior.

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,14 +24,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-19";
+} from "./shared.js?v=20260819-20";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260817-19";
+} from "./engagement.js?v=20260819-20";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -43,6 +43,7 @@ import {
   inlineSearchCompletionSuffix,
   matchesCommittedSearchTerm,
   matchesDraftSearchTerm,
+  matchesFullPluginId,
   matchesShortSearch,
   maximumSearchTerms,
   normalizeSearchTerm,
@@ -53,8 +54,9 @@ import {
   searchTermDisplayValue,
   searchTermKey,
   searchTokens,
+  searchablePluginId,
   selectSearchCompletions,
-} from "./search.js?v=20260817-19";
+} from "./search.js?v=20260819-20";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);
@@ -187,7 +189,7 @@ function pluginSearchText(plugin) {
     plugin.author,
     publisher,
     `@${publisher}`,
-    plugin.id,
+    searchablePluginId(plugin.id),
     plugin.category,
     plugin.kind,
     ...(plugin.tags || [])
@@ -199,9 +201,10 @@ function directPluginTokenMatch(plugin, token) {
     const requested = token.slice(1).toLocaleLowerCase();
     return publisherLogin(plugin).toLocaleLowerCase().startsWith(requested);
   }
+  if (matchesFullPluginId(token, plugin.id)) return true;
   const text = pluginSearchText(plugin);
   if (token.length > 3) return text.includes(token);
-  const primaryText = [plugin.name, plugin.id, ...(plugin.tags || [])].join(" ");
+  const primaryText = [plugin.name, searchablePluginId(plugin.id), ...(plugin.tags || [])].join(" ");
   return matchesShortSearch(token, primaryText, text);
 }
 
@@ -213,7 +216,7 @@ function directPluginMatch(plugin, value) {
 
 function pluginMatchesActiveSearch(plugin) {
   const publisher = publisherLogin(plugin);
-  const primaryText = [plugin.name, plugin.id, ...(plugin.tags || [])].join(" ");
+  const primaryText = [plugin.name, searchablePluginId(plugin.id), ...(plugin.tags || [])].join(" ");
   const searchText = pluginSearchText(plugin);
   const hasTerms = state.terms.length > 0;
   const draftTerms = parseSearchDraft(state.query);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-19";
+} from "./shared.js?v=20260819-20";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -19,7 +19,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260817-19";
+} from "./shared.js?v=20260819-20";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -27,7 +27,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260817-19";
+} from "./engagement.js?v=20260819-20";
 
 function statusTone(plugin) {
   if (plugin.upstreamCheckStatus === "failed") return "is-failed";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260817-19";
+} from "./shared.js?v=20260819-20";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -176,6 +176,17 @@ export function removeSearchTermTypeFromDraft(value, type) {
     .join(" ");
 }
 
+const reverseDnsNamespacePattern = /^[a-z]{2,4}\.[a-z0-9-]+\.(?=.)/i;
+
+export function searchablePluginId(value) {
+  return String(value || "").replace(reverseDnsNamespacePattern, "");
+}
+
+export function matchesFullPluginId(query, pluginId) {
+  const requested = foldSearchTerm(query);
+  return requested.includes(".") && foldSearchTerm(pluginId).includes(requested);
+}
+
 export function matchesShortSearch(query, primaryText, searchText) {
   const normalized = foldSearchTerm(String(query || "").replace(/^@/, ""));
   if (!normalized) return true;
@@ -207,6 +218,7 @@ export function matchesCommittedSearchTerm(term, {
   if (normalized.type === "plugin") {
     return foldSearchTerm(pluginName) === requested || foldSearchTerm(pluginId) === requested;
   }
+  if (matchesFullPluginId(requested, pluginId)) return true;
   if (requested.length > 3 || requested.includes(" ")) {
     return foldSearchTerm(searchText).includes(requested);
   }

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260817-19"></script>
+    <script type="module" src="assets/js/develop.js?v=20260819-20"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260817-19"></script>
+    <script type="module" src="assets/js/app.js?v=20260819-20"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260817-19"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260819-20"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260817-19"></script>
+    <script type="module" src="assets/js/publish.js?v=20260819-20"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -59,6 +59,7 @@ import {
   inlineSearchCompletionSuffix,
   matchesCommittedSearchTerm,
   matchesDraftSearchTerm,
+  matchesFullPluginId,
   matchesShortSearch,
   maximumSearchTermLength,
   parseSearchDraft,
@@ -68,6 +69,7 @@ import {
   searchKeyAction,
   searchTermKey,
   searchTokens,
+  searchablePluginId,
   selectSearchCompletions,
   uniqueSearchTerms,
 } from "../site/assets/js/search.js";
@@ -257,6 +259,43 @@ test("inline completion accepts genuine plugin, tag, and author prefixes", () =>
     { type: "author", value: "spaceXrace" },
     "space",
   ), "");
+});
+
+test("searchable plugin ids drop the reverse-DNS host namespace", () => {
+  assert.equal(searchablePluginId("io.github.elynch303.fan-monitor"), "elynch303.fan-monitor");
+  assert.equal(searchablePluginId("com.github.murphi.openfortivpn"), "murphi.openfortivpn");
+  assert.equal(searchablePluginId("dev.deoxizn.bardisplay"), "bardisplay");
+  assert.equal(searchablePluginId("sh.lerd.glance"), "glance");
+  assert.equal(searchablePluginId("dizziee.power-profiles"), "dizziee.power-profiles");
+  assert.equal(searchablePluginId("omarchy-overview"), "omarchy-overview");
+  assert.equal(searchablePluginId("lacuna.shell-suite"), "lacuna.shell-suite");
+  assert.equal(searchablePluginId(""), "");
+});
+
+test("dotted queries still match the full reverse-DNS plugin id", () => {
+  assert.equal(matchesFullPluginId("io.github.elynch303.fan-monitor", "io.github.elynch303.fan-monitor"), true);
+  assert.equal(matchesFullPluginId("elynch303.fan-monitor", "io.github.elynch303.fan-monitor"), true);
+  assert.equal(matchesFullPluginId("github", "io.github.elynch303.fan-monitor"), false);
+  assert.equal(matchesFullPluginId("fan-monitor", "io.github.elynch303.fan-monitor"), false);
+});
+
+test("host namespaces in plugin ids do not match unrelated text searches", () => {
+  const plugin = {
+    publisher: "elynch303",
+    primaryText: "Fan Monitor elynch303.fan-monitor bar",
+    searchText: "fan monitor elynch303 @elynch303 elynch303.fan-monitor system bar",
+    tags: ["bar"],
+    pluginName: "Fan Monitor",
+    pluginId: "io.github.elynch303.fan-monitor",
+  };
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("text", "github"), plugin), false);
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("text", "git"), plugin), false);
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("text", "fan"), plugin), true);
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("text", "elynch303"), plugin), true);
+  assert.equal(
+    matchesCommittedSearchTerm(createSearchTerm("text", "io.github.elynch303.fan-monitor"), plugin),
+    true,
+  );
 });
 
 test("typed committed chips use exact field-specific matching", () => {
@@ -613,7 +652,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260817-19");
+  assert.equal(keys[0], "20260819-20");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));


### PR DESCRIPTION
Searching `github` currently matches 175 of 563 listings, which makes it impossible to find the actual GitHub plugins.

The cause is plugin IDs. 168 catalog entries use the reverse-DNS `io.github.<user>.<name>` form, and the raw ID was indexed as free-text alongside the name, description, and tags. Any query longer than three characters is a substring test, so the literal `github` in the namespace prefix matched every one of them. The short-token path had the same problem, so `git` leaked too.

This indexes only the meaningful ID segments and drops the leading `<tld>.<host>.` namespace, which is duplicated by the publisher field anyway. Against the current catalog, `github` goes from 175 matches to 8, all genuinely GitHub-related, and `git` goes to 16.

Full IDs stay searchable: any query containing a dot is still tested against the complete ID, and typed `plugin:` terms are unchanged.

## Test plan

- [x] `npm test` (164 passing), including new unit tests for namespace stripping, dotted full-ID queries, and the `github`/`git` regression
- [x] Filtering verified against the real `site/catalog.json` through the actual `search.js` module
- [ ] Runtime check in the browser: search `github`, `git`, a full `io.github.*` ID, and a `plugin:` chip

Not addressed here: search results are still ordered by the sort dropdown rather than relevance, so the plugin named GitHub is not guaranteed to be first among the 8. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)