### PR TITLE
Allow animated WebP previews

### DIFF
--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -13,7 +13,7 @@ Before submitting, confirm that the repository:
 - Uses a globally unique plugin ID outside the reserved `omarchy.*` namespace
 - Optionally contains one root preview named `preview.png`, `preview.jpg`, `preview.jpeg`, `preview.webp`, or `preview.avif`
 
-The marketplace removes preview metadata and generates optimized card and detail images automatically. Normal screenshots need no manual resizing or compression. Preview input is limited to 50 MB and 40 megapixels to protect the build runner from malformed or exceptionally large images.
+The marketplace removes preview metadata and generates optimized card and detail images automatically. Normal screenshots need no manual resizing or compression. Animated WebP previews keep their animation on the plugin detail page (the card thumbnail stays a still). Preview input is limited to 50 MB and 40 megapixels to protect the build runner from malformed or exceptionally large images; for animations the 40-megapixel limit applies to all frames combined.
 
 Marketplace validation checks repository structure and Omarchy Quattro compatibility. It is not a security review, and plugins run as unsandboxed upstream code.
 

--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -30,6 +30,10 @@ export const previewByteLimit = 50 * 1024 * 1024;
 export const previewPixelLimit = 40_000_000;
 export const previewCardLimit = 720;
 export const previewDetailLimit = 1600;
+// Animated WebP previews: the per-frame pixel limit stays `previewPixelLimit`;
+// the whole animation additionally has to fit the same budget summed across
+// frames, so a long clip must use a small frame and a big frame a short clip.
+export const previewAnimationPixelBudget = previewPixelLimit;
 const fileLimit = 1024 * 1024;
 const requestTimeout = 15_000;
 const accents = ["lime", "amber", "coral", "cyan", "violet", "rose"];
@@ -530,10 +534,19 @@ export async function optimizePreviewBuffer(buffer, repository) {
       failOn: "error",
       limitInputPixels: previewPixelLimit,
     });
+    // Metadata is read without `animated`, so width/height describe a single
+    // frame (with `animated: true` sharp reports the stacked frame roll).
     const metadata = validatePreviewMetadata(
       await image.metadata(),
       `${repository.slug} preview`,
     );
+    const animated = metadata.format === "webp" && (metadata.pages ?? 1) > 1;
+    if (animated && metadata.pages * metadata.width * metadata.height > previewAnimationPixelBudget) {
+      checkError(
+        "preview-invalid",
+        `${repository.slug} preview animation exceeds the ${previewAnimationPixelBudget}-pixel budget (frames × width × height)`,
+      );
+    }
     const card = await image
       .clone()
       .rotate()
@@ -545,8 +558,12 @@ export async function optimizePreviewBuffer(buffer, repository) {
       })
       .webp({ quality: 78, alphaQuality: 85, effort: 4, smartSubsample: true })
       .toBuffer({ resolveWithObject: true });
-    const detail = await image
-      .clone()
+    // The card stays a still (first frame): a grid of looping animations is
+    // distracting. The detail image keeps the animation when the source has one.
+    const detailSource = animated
+      ? sharp(buffer, { failOn: "error", limitInputPixels: previewPixelLimit, animated: true })
+      : image.clone();
+    const detail = await detailSource
       .rotate()
       .resize({
         width: previewDetailLimit,
@@ -556,6 +573,7 @@ export async function optimizePreviewBuffer(buffer, repository) {
       })
       .webp({ quality: 82, alphaQuality: 90, effort: 4, smartSubsample: true })
       .toBuffer({ resolveWithObject: true });
+    const detailHeight = animated ? (detail.info.pageHeight ?? detail.info.height) : detail.info.height;
     const fileBase = previewFileBase(repository);
     const cardFileName = `${fileBase}-card.webp`;
     const detailFileName = `${fileBase}-detail.webp`;
@@ -568,12 +586,13 @@ export async function optimizePreviewBuffer(buffer, repository) {
       metadata: {
         previewImage: `assets/img/plugins/${detailFileName}`,
         previewWidth: detail.info.width,
-        previewHeight: detail.info.height,
+        previewHeight: detailHeight,
         previewThumbnail: `assets/img/plugins/${cardFileName}`,
         previewThumbnailWidth: card.info.width,
         previewThumbnailHeight: card.info.height,
         previewSourceWidth: metadata.width,
         previewSourceHeight: metadata.height,
+        ...(animated ? { previewAnimated: true } : {}),
       },
     };
   } catch (error) {

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import sharp from "sharp";
 import {
   applyVersionState,
   assertRecoverableCatalogError,
@@ -20,6 +21,8 @@ import {
   snapshotHttpErrorCode,
   successfulState,
   upstreamCheckErrorCodes,
+  optimizePreviewBuffer,
+  previewAnimationPixelBudget,
   validateBeforeStagingPreview,
 } from "../scripts/build-catalog.mjs";
 import {
@@ -854,4 +857,55 @@ test("SHIBUMI is listed once as a manual shell suite", () => {
   assert.equal(shibumi.installCommand, "");
   assert.match(shibumi.previewImage, /^assets\/img\/plugins\/.*-detail\.webp$/);
   assert.match(shibumi.previewThumbnail, /^assets\/img\/plugins\/.*-card\.webp$/);
+});
+
+async function animatedWebp(frames, width, height) {
+  const buffers = [];
+  for (const background of frames) {
+    buffers.push(await sharp({ create: { width, height, channels: 3, background } }).png().toBuffer());
+  }
+  return sharp(buffers, { join: { animated: true } }).webp({ effort: 0 }).toBuffer();
+}
+
+const previewRepository = { slug: "acme/omarchy-demo", owner: "acme", repository: "omarchy-demo" };
+
+test("animated webp previews keep their animation in the detail image", async () => {
+  const source = await animatedWebp(["#ff0000", "#00ff00", "#0000ff"], 900, 600);
+  const result = await optimizePreviewBuffer(source, previewRepository);
+  const [card, detail] = result.outputs;
+  const cardMetadata = await sharp(card.buffer).metadata();
+  const detailMetadata = await sharp(detail.buffer).metadata();
+  assert.equal(cardMetadata.pages ?? 1, 1, "card thumbnail stays a still image");
+  assert.equal(detailMetadata.pages, 3, "detail image keeps every frame");
+  assert.equal(result.metadata.previewAnimated, true);
+  assert.equal(result.metadata.previewWidth, 900);
+  assert.equal(result.metadata.previewHeight, 600, "reported height is a single frame, not the frame roll");
+});
+
+test("animated webp previews are resized per frame like still previews", async () => {
+  const source = await animatedWebp(["#ff0000", "#00ff00"], 3200, 1000);
+  const result = await optimizePreviewBuffer(source, previewRepository);
+  const detailMetadata = await sharp(result.outputs[1].buffer).metadata();
+  assert.equal(detailMetadata.pages, 2);
+  assert.equal(result.metadata.previewWidth, 1600);
+  assert.equal(result.metadata.previewHeight, 500);
+});
+
+test("animated webp previews over the frame budget are rejected", async () => {
+  const frames = Array.from({ length: 12 }, (_, index) => `#${((index * 1234567) % 0xffffff).toString(16).padStart(6, "0")}`);
+  const source = await animatedWebp(frames, 2000, 2000);
+  assert.ok(12 * 2000 * 2000 > previewAnimationPixelBudget, "fixture exceeds the budget");
+  await assert.rejects(
+    optimizePreviewBuffer(source, previewRepository),
+    (error) => error instanceof CatalogCheckError && /animation exceeds/.test(error.message),
+  );
+});
+
+test("still webp previews keep the existing static pipeline", async () => {
+  const source = await sharp({ create: { width: 2400, height: 1200, channels: 3, background: "#987654" } }).webp().toBuffer();
+  const result = await optimizePreviewBuffer(source, previewRepository);
+  const detailMetadata = await sharp(result.outputs[1].buffer).metadata();
+  assert.equal(detailMetadata.pages ?? 1, 1);
+  assert.equal(result.metadata.previewAnimated, undefined);
+  assert.equal(result.metadata.previewWidth, 1600);
 });


### PR DESCRIPTION
I built this because I'd like to use an animated preview for my own plugin, only on the plugin page, not in the index where it would be too distracting if proved to be popular.

If you don't want any animated stuff on plugin page - i understand, close this without ceremony :)


## What

Animated WebP previews currently get flattened to their first frame: the pipeline opens the source without sharp's animated mode and re-encodes a single frame. This PR keeps the animation on the **plugin detail page**, while the **card thumbnail in the grid intentionally stays a still** (first frame) — a grid full of looping animations would compete for attention.

## How

- `optimizePreviewBuffer` detects animation via `metadata.pages > 1` (WebP only; animated GIF/AVIF keep the current flattening behaviour).
- The detail image is built from a second sharp instance with `animated: true` — same resize and quality settings as today, applied per frame.
- Still images take the exact same path as before (covered by a test).
- Catalog entries for animated previews get an additive `previewAnimated: true` field and report **single-frame** dimensions — with `animated: true` sharp reports the stacked "frame roll" height, so validation and reported dimensions come from the non-animated metadata read.

## Guardrails

No new limits or config knobs: the existing 40 MP `previewPixelLimit` also applies to the whole animation **summed across frames** (`frames × width × height ≤ 40 MP`), so decode cost on the build runner stays bounded — a long clip forces a small frame and vice versa. A ~1400×650 frame allows ~43 frames.

## Tests

Four new tests in `test/catalog.test.js` (generated fixtures via sharp): animation preserved in detail + still card, per-frame resizing, over-budget rejection, and the unchanged still-image path. Full suite: 165/165 passing. Also verified against a real 40-frame 1406×656 plugin hero animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
