### PR TITLE
Clarify plugin detail verification status

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -433,13 +433,15 @@ svg {
   background: linear-gradient(90deg, transparent, var(--line) 12%, var(--line) 88%, transparent);
   content: "";
 }
+.detail-section-before-verification > .command-panel:last-child { margin-bottom: 0; }
+.detail-section#install + .detail-section#verification { padding-top: 0; }
+.detail-section#install + .detail-section#verification::before { content: none; }
 .detail-section h2, .docs-section h2 { margin: 0 0 12px; font-size: 20px; }
 .detail-section p, .docs-section > p { margin: 0; color: var(--muted); line-height: 1.7; }
 .install-note { margin: 10px 0 0; color: var(--muted); line-height: 1.7; }
 .placeholder-install { padding: 15px; border: 1px dashed var(--line); background: var(--panel); }
 .command-panel + .builtin-availability, .command-panel + .install-note + .install-security-note { margin-top: 12px; }
 .install-note:empty { display: none; }
-.install-security-note + .verification-status-note,
 .terms-source-note + .listing-checks, .terms-source-note + .terms-source-note,
 .listing-checks + .terms-source-note { margin-top: 12px; }
 .placeholder-install strong { color: var(--accent); }
@@ -447,12 +449,13 @@ svg {
   color: var(--text); text-decoration: underline; text-underline-offset: 3px;
 }
 .placeholder-install a:hover, .install-security-note a:hover { color: var(--accent); }
+.security-notice-section .install-security-note { margin: 0; }
 .placeholder-install p { margin: 5px 0 0; color: var(--muted); line-height: 1.7; }
-.verification-status-note > strong,
 .verification-status-note .verification-contributor-action strong { color: var(--text); }
 .verification-status-note .verification-snapshot strong { color: var(--stable); }
-.verification-status-note .verification-update strong { color: var(--accent); }
-.verification-status-list { padding: 0; margin: 4px 0 0; list-style: none; }
+.verification-status-note .verification-update strong,
+.verification-status-note .verification-unverified strong { color: var(--accent); }
+.verification-status-list { padding: 0; margin: 0; list-style: none; }
 .verification-status-list li {
   position: relative; padding-left: 24px; margin: 8px 0; color: var(--muted);
   font-size: 15px; line-height: 1.72;

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,14 +24,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260820-22";
+} from "./shared.js?v=20260820-23";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260820-22";
+} from "./engagement.js?v=20260820-23";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -54,7 +54,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260820-22";
+} from "./search.js?v=20260820-23";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260820-22";
+} from "./shared.js?v=20260820-23";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -6,8 +6,10 @@ import {
   escapeHtml,
   formatDate,
   formatStars,
+  hasExactVerificationSnapshot,
   hidePendingEngagement,
   listingCheckState,
+  listingCommitComparison,
   loadCatalog,
   pluginHeartButton,
   pluginVerificationDetailState,
@@ -18,7 +20,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260820-22";
+} from "./shared.js?v=20260820-23";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -26,7 +28,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260820-22";
+} from "./engagement.js?v=20260820-23";
 
 function safeGitHubWebUrl(value) {
   try {
@@ -42,6 +44,15 @@ function safeGitHubWebUrl(value) {
   } catch {
     return "";
   }
+}
+
+function marketplaceInstallAvailable(plugin) {
+  return Boolean(plugin.installAvailable && plugin.upstreamCheckStatus !== "failed");
+}
+
+function displayedStatus(plugin) {
+  if (plugin.upstreamCheckStatus === "failed") return "Compatibility failed";
+  return plugin.status || (marketplaceInstallAvailable(plugin) ? "Available" : "Installation unavailable");
 }
 
 function statusTone(plugin) {
@@ -96,7 +107,7 @@ function setupDetailMetaLineStarts(root) {
   root.ownerDocument.defaultView?.addEventListener("resize", update);
 }
 
-function detailTemplate(plugin, engagement, {
+export function detailTemplate(plugin, engagement, {
   engagementEnabled = false,
   hearted = false,
   pendingEngagement = false,
@@ -107,7 +118,13 @@ function detailTemplate(plugin, engagement, {
   const preview = plugin.previewImage
     ? `<figure class="detail-preview"><img src="${escapeHtml(plugin.previewImage)}" alt="${escapeHtml(plugin.name)} desktop preview" width="${Number(plugin.previewWidth) || 1600}" height="${Number(plugin.previewHeight) || 900}"></figure>`
     : "";
-  const command = plugin.builtIn ? plugin.officialCommand : plugin.installCommand;
+  const installAvailable = marketplaceInstallAvailable(plugin);
+  const pluginStatus = displayedStatus(plugin);
+  const command = plugin.builtIn
+    ? plugin.officialCommand
+    : installAvailable
+      ? plugin.installCommand
+      : "";
   const commandLabel = plugin.builtIn ? plugin.officialCommandLabel : "Install current upstream";
   const copyCommandLabel = plugin.builtIn
     ? `Copy ${commandLabel.toLowerCase()} command`
@@ -118,20 +135,46 @@ function detailTemplate(plugin, engagement, {
           <span class="copy-icon" aria-hidden="true"></span><span data-copy-label>Copy</span>
           <span class="control-tooltip" role="tooltip" aria-hidden="true">${escapeHtml(copyCommandLabel)}</span>
         </button></div><pre><code><span class="prompt">❯</span> ${escapeHtml(command)}</code></pre></div>` : "";
-  const snapshotNotice = plugin.verificationSnapshotStatus === "verified"
-    ? `<li class="verification-snapshot"><strong>Snapshot verified:</strong> Marketplace verification covers only the exact commit shown under Listing checks.</li>`
-    : "";
-  const updateNotice = plugin.verificationCoverage === "update-unverified"
+  const isThirdPartyListing = plugin.sourceType === "community"
+    && !plugin.builtIn
+    && !plugin.placeholder;
+  const verificationEligible = isThirdPartyListing && plugin.repositoryLayout !== "suite";
+  const canRequestVerification = verificationEligible;
+  const snapshotVerified = verificationEligible && hasExactVerificationSnapshot(plugin);
+  const verificationDetail = pluginVerificationDetailState(plugin);
+  const updateUnverified = snapshotVerified && verificationDetail?.coverage === "update-unverified";
+  const snapshotNotice = !verificationEligible && isThirdPartyListing
+    ? `<li class="verification-unverified"><strong>Verification unavailable:</strong> Suite listings are outside the plugin verification workflow.</li>`
+    : snapshotVerified
+      ? `<li class="verification-snapshot"><strong>Snapshot verified:</strong> Marketplace verification covers only the exact commit shown under Listing checks.</li>`
+      : isThirdPartyListing
+        ? `<li class="verification-unverified"><strong>Snapshot unverified:</strong> This listed commit has not been verified.</li>`
+        : "";
+  const updateNotice = updateUnverified
     ? `<li class="verification-update"><strong>Update unverified:</strong> The latest upstream changes have not been verified.</li>`
     : "";
-  const contributorAction = plugin.verificationCoverage === "update-unverified"
+  const contributorAction = canRequestVerification && updateUnverified
     ? `<li class="verification-contributor-action"><strong>Contributor action:</strong> Submit the new exact commit through the <a href="${verificationRequestUrl}" target="_blank" rel="noreferrer">plugin verification form <span aria-hidden="true">↗</span></a>.</li>`
+    : canRequestVerification && !snapshotVerified
+      ? `<li class="verification-contributor-action"><strong>Contributor action:</strong> Submit the exact listed commit through the <a href="${verificationRequestUrl}" target="_blank" rel="noreferrer">plugin verification form <span aria-hidden="true">↗</span></a>.</li>`
+      : "";
+  const verificationStatusSection = isThirdPartyListing
+    ? `<section class="detail-section" id="verification"><h2>Verification status</h2><div class="placeholder-install verification-status-note"><ul class="verification-status-list">${snapshotNotice}${updateNotice}${contributorAction}</ul></div></section>`
     : "";
-  const verificationStatusNotice = snapshotNotice
-    ? `<div class="placeholder-install verification-status-note"><strong>Verification status</strong><ul class="verification-status-list">${snapshotNotice}${updateNotice}${contributorAction}</ul></div>`
+  const securityContext = plugin.upstreamCheckStatus === "failed"
+    ? "Marketplace installation is unavailable because compatibility has not been confirmed. Installation through another method is not bound to the marketplace’s listed or verified snapshot and may install or execute different code."
+    : command
+      ? "This Omarchy command clones the repository’s current HEAD. It is not bound to the marketplace’s verified snapshot and may install a different commit. Check the installed commit before enabling it."
+      : pluginStatus === "Manual setup"
+        ? "Manual installation follows the upstream project’s instructions. It is not bound to the marketplace’s listed or verified snapshot and may install or execute different code. Check the installed commit before enabling it."
+        : "Marketplace installation is unavailable because compatibility has not been confirmed. Installation through another method is not bound to the marketplace’s listed or verified snapshot and may install or execute different code.";
+  const installSecurityNotice = isThirdPartyListing
+    ? `<div class="callout prominent-callout install-security-note"><strong id="security-notice-title">Security Notice</strong><p>${securityContext}</p><p>Third-party plugins run as unsandboxed code. Automated checks are limited and are not a security audit or guarantee. Inspect the source and capabilities, and <a href="${securityReportUrl}" target="_blank" rel="noreferrer">report suspicious plugins ASAP <span aria-hidden="true">↗</span></a>.</p></div>`
     : "";
-  const installSecurityNotice = `<div class="callout prominent-callout install-security-note"><strong>Security Notice</strong><p>This Omarchy command clones the repository’s current HEAD. It is not bound to the marketplace’s verified snapshot and may install a different commit. Check the installed commit before enabling it.</p><p>Third-party plugins run as unsandboxed code. Automated checks are limited and are not a security audit or guarantee. Inspect the source and capabilities, and <a href="${securityReportUrl}" target="_blank" rel="noreferrer">report suspicious plugins ASAP <span aria-hidden="true">↗</span></a>.</p></div>`;
-  const displayedInstallNote = plugin.installAvailable && plugin.repositoryLayout === "root-plugin"
+  const securityNoticeSection = installSecurityNotice
+    ? `<section class="detail-section security-notice-section" id="security" aria-labelledby="security-notice-title">${installSecurityNotice}</section>`
+    : "";
+  const displayedInstallNote = installAvailable && plugin.repositoryLayout === "root-plugin"
     ? ""
     : plugin.installNote || "";
   const installNote = displayedInstallNote
@@ -141,11 +184,11 @@ function detailTemplate(plugin, engagement, {
     ? `${commandPanel}<div class="placeholder-install builtin-availability"><strong>Included with Omarchy Quattro</strong><p>This first-party plugin ships with Omarchy. The command configures the included plugin; it does not download marketplace code.</p></div>`
     : plugin.placeholder
       ? `<div class="placeholder-install"><strong>Coming soon</strong><p>${escapeHtml(plugin.installNote)}</p></div>`
-      : !plugin.installAvailable
-        ? `<div class="placeholder-install"><strong>${escapeHtml(plugin.status || "Installation unavailable")}</strong><p>${escapeHtml(plugin.installNote || "")}</p></div>`
-        : `${commandPanel}${installNote}${installSecurityNotice}${verificationStatusNotice}`;
+      : !installAvailable
+        ? `<div class="placeholder-install"><strong>${escapeHtml(pluginStatus)}</strong><p>${escapeHtml(plugin.installNote || "")}</p></div>`
+        : `${commandPanel}${installNote}`;
 
-  const availabilityHeading = plugin.builtIn || plugin.placeholder || !plugin.installAvailable
+  const availabilityHeading = plugin.builtIn || plugin.placeholder || !installAvailable
     ? "Availability"
     : "Install";
   const sourceNote = plugin.builtIn
@@ -176,8 +219,9 @@ function detailTemplate(plugin, engagement, {
     }).format(new Date(value));
   };
   const check = listingCheckState(plugin);
+  const comparedCommits = listingCommitComparison(plugin);
   const comparison = check.comparison === "changed"
-    ? `<a href="${escapeHtml(`${repositoryUrl}/compare/${plugin.listingValidatedCommit}...${plugin.upstreamObservedCommit}`)}" target="_blank" rel="noreferrer">View changes <span aria-hidden="true">↗</span></a>`
+    ? `<a href="${escapeHtml(`${repositoryUrl}/compare/${comparedCommits.listingCommit}...${comparedCommits.upstreamCommit}`)}" target="_blank" rel="noreferrer">View changes <span aria-hidden="true">↗</span></a>`
     : check.comparison === "unknown"
       ? "Could not determine"
       : "No changes detected";
@@ -201,7 +245,7 @@ function detailTemplate(plugin, engagement, {
           <div class="listing-check-row"><dt>${check.commitLabel}</dt><dd>${commitLink(check.checkedCommit, `View ${check.commitLabel.toLowerCase()}`)}</dd></div>
           ${lastSuccessful}
           ${lastCompatible}
-          <div class="listing-check-row"><dt>${plugin.verificationSnapshotStatus === "verified" ? "Verified snapshot" : "Listing snapshot"}</dt><dd>${commitLink(plugin.listingValidatedCommit, plugin.verificationSnapshotStatus === "verified" ? "View verified snapshot" : "View listing snapshot")}<small>${escapeHtml(formatDate(plugin.listingValidatedAt))}</small></dd></div>
+          <div class="listing-check-row"><dt>${snapshotVerified ? "Verified snapshot" : "Listing snapshot"}</dt><dd>${commitLink(plugin.listingValidatedCommit, snapshotVerified ? "View verified snapshot" : "View listing snapshot")}<small>${escapeHtml(formatDate(plugin.listingValidatedAt))}</small></dd></div>
           <div class="listing-check-row"><dt>Branch</dt><dd>${branchLink}</dd></div>
           <div class="listing-check-row"><dt>Upstream changes</dt><dd>${comparison}</dd></div>
         </dl>
@@ -217,14 +261,16 @@ function detailTemplate(plugin, engagement, {
     <article class="plugin-detail-article" style="--card-accent:${accentColor(plugin.accent)}">
       <header class="page-header" id="overview"><div class="page-eyebrow">${escapeHtml(plugin.category)}</div>
         <div class="detail-title"><span class="detail-icon">${escapeHtml(plugin.initials)}</span><h1>${escapeHtml(plugin.name)}</h1></div>
-        <div class="page-meta"><span>${escapeHtml(plugin.id)}</span>${manifestVersion}<span>by ${escapeHtml(plugin.author)}</span><span class="detail-status-meta"><span class="status ${statusTone(plugin)}"><i class="status-dot" aria-hidden="true"></i>${escapeHtml(plugin.status || "Available")}</span>${verificationBadge}</span></div>
+        <div class="page-meta"><span>${escapeHtml(plugin.id)}</span>${manifestVersion}<span>by ${escapeHtml(plugin.author)}</span><span class="detail-status-meta"><span class="status ${statusTone(plugin)}"><i class="status-dot" aria-hidden="true"></i>${escapeHtml(pluginStatus)}</span>${verificationBadge}</span></div>
         ${engagementEnabled ? `<div class="detail-engagement-cluster">
           ${engagementSummary(plugin, engagement, { detail: true, pending: pendingEngagement })}
           ${pluginHeartButton(plugin, engagement, { detail: true, hearted, pending: pendingEngagement })}
         </div>` : ""}
       </header>
       <p class="detail-description">${escapeHtml(plugin.description)}</p>${preview}<div class="plugin-tags">${tags}</div>
-      <section class="detail-section" id="install"><h2>${plugin.builtIn ? escapeHtml(plugin.officialCommandLabel) : availabilityHeading}</h2>${install}</section>
+      <section class="detail-section${isThirdPartyListing ? " detail-section-before-verification" : ""}" id="install"><h2>${plugin.builtIn ? escapeHtml(plugin.officialCommandLabel) : availabilityHeading}</h2>${install}</section>
+      ${verificationStatusSection}
+      ${securityNoticeSection}
       <section class="detail-section" id="terms"><h2>Terms of Use</h2>${sourceNote}${provenance}<p style="margin-top:18px"><a class="button primary" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noreferrer">View source ↗</a></p></section>
     </article>`;
 }
@@ -291,6 +337,8 @@ async function init() {
     });
     setupControlTooltips(content);
     setupDetailMetaLineStarts(content);
+    document.querySelector("#aside-verification-link").hidden = !content.querySelector("#verification");
+    document.querySelector("#aside-security-link").hidden = !content.querySelector("#security");
     if (currentHashId() === "trust") {
       const url = new URL(location.href);
       url.hash = "terms";
@@ -324,7 +372,7 @@ async function init() {
         });
       }
     }
-    document.querySelector("#aside-status").innerHTML = `<span class="status-label ${statusTone(plugin)}">${escapeHtml(plugin.status || "Available")}</span>`;
+    document.querySelector("#aside-status").innerHTML = `<span class="status-label ${statusTone(plugin)}">${escapeHtml(displayedStatus(plugin))}</span>`;
     const verification = pluginVerificationDetailState(plugin);
     const verificationRow = document.querySelector("#aside-verification-row");
     verificationRow.hidden = !verification;
@@ -337,7 +385,7 @@ async function init() {
       : "—";
     document.querySelector("#aside-license").textContent = plugin.license || "Unknown";
     document.querySelector("#aside-owner").textContent = plugin.author;
-    if (plugin.builtIn || plugin.placeholder || !plugin.installAvailable) {
+    if (plugin.builtIn || plugin.placeholder || !marketplaceInstallAvailable(plugin)) {
       const navigationLabel = plugin.builtIn ? plugin.officialCommandLabel : "Availability";
       document.querySelector("#aside-install-link").textContent = navigationLabel;
       document.querySelector("#mobile-install-link").textContent = plugin.builtIn
@@ -420,4 +468,4 @@ async function init() {
   }
 }
 
-init();
+if (typeof document !== "undefined") init();

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260820-22";
+} from "./shared.js?v=20260820-23";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/shared.js
+++ b/site/assets/js/shared.js
@@ -264,6 +264,26 @@ function fullCommit(value) {
   return /^[a-f0-9]{40}$/i.test(value || "") ? value.toLowerCase() : "";
 }
 
+export function listingCommitComparison(plugin) {
+  const listingCommit = fullCommit(plugin?.listingValidatedCommit);
+  const upstreamCommit = fullCommit(plugin?.upstreamObservedCommit)
+    || fullCommit(plugin?.upstreamValidatedCommit);
+  const comparison = !listingCommit || !upstreamCommit
+    ? "unknown"
+    : upstreamCommit === listingCommit
+      ? "unchanged"
+      : "changed";
+  return { listingCommit, upstreamCommit, comparison };
+}
+
+export function hasExactVerificationSnapshot(plugin) {
+  const verificationCommit = fullCommit(plugin?.verificationCommit);
+  const { listingCommit } = listingCommitComparison(plugin);
+  return plugin?.verificationSnapshotStatus === "verified"
+    && Boolean(verificationCommit)
+    && verificationCommit === listingCommit;
+}
+
 export function matchesVerificationStatus(plugin, status) {
   return !plugin?.builtIn
     && plugin?.repositoryLayout !== "suite"
@@ -289,27 +309,28 @@ export function pluginVerificationState(plugin) {
 }
 
 export function pluginVerificationDetailState(plugin) {
-  if (plugin?.builtIn) return null;
+  if (plugin?.builtIn || plugin?.repositoryLayout === "suite") return null;
   if (
-    plugin?.verificationStatus === "verified"
-    || plugin?.verificationCoverage === "update-unverified"
+    hasExactVerificationSnapshot(plugin)
+    && (
+      plugin?.verificationStatus === "verified"
+      || plugin?.verificationCoverage === "update-unverified"
+    )
   ) {
     const verifiedCommit = fullCommit(plugin.verificationCommit);
-    const observedCommit = fullCommit(
-      plugin.upstreamObservedCommit || plugin.upstreamValidatedCommit,
-    );
-    const updateUnverified = plugin?.verificationCoverage === "update-unverified" || Boolean(
-      verifiedCommit
-      && observedCommit
-      && observedCommit !== verifiedCommit
-    );
+    const { upstreamCommit } = listingCommitComparison(plugin);
+    const updateUnverified = plugin?.verificationCoverage === "update-unverified"
+      || !upstreamCommit
+      || upstreamCommit !== verifiedCommit;
     if (updateUnverified) {
       return {
         status: "unverified",
         coverage: "update-unverified",
         label: "Snapshot verified. Update unverified",
         markerLabels: ["Snapshot verified", "Update unverified"],
-        explanation: "The current upstream commit differs from the verified snapshot. The update and mutable upstream install command are not covered by that verification.",
+        explanation: upstreamCommit
+          ? "The current upstream commit differs from the verified snapshot. The update and mutable upstream install command are not covered by that verification."
+          : "The current upstream commit could not be confirmed. The mutable upstream install command is not covered by the snapshot verification.",
       };
     }
     return {
@@ -332,19 +353,15 @@ export function pluginVerificationDetailState(plugin) {
 }
 
 export function listingCheckState(plugin) {
-  const upstreamChanged = Boolean(
-    plugin?.upstreamObservedCommit
-    && plugin?.listingValidatedCommit
-    && plugin.upstreamObservedCommit !== plugin.listingValidatedCommit
-  );
+  const { upstreamCommit, comparison } = listingCommitComparison(plugin);
 
   if (plugin?.upstreamCheckStatus === "passed") {
     return {
       statusLabel: "Passed",
       statusTone: "is-passed",
       commitLabel: "Checked commit",
-      checkedCommit: plugin.upstreamValidatedCommit,
-      comparison: upstreamChanged ? "changed" : "unchanged",
+      checkedCommit: upstreamCommit,
+      comparison,
     };
   }
 
@@ -353,9 +370,9 @@ export function listingCheckState(plugin) {
       statusLabel: "Failed",
       statusTone: "is-failed",
       commitLabel: "Checked commit",
-      checkedCommit: plugin.upstreamObservedCommit,
-      lastCompatibleCommit: plugin.upstreamValidatedCommit,
-      comparison: upstreamChanged ? "changed" : "unchanged",
+      checkedCommit: upstreamCommit,
+      lastCompatibleCommit: fullCommit(plugin.upstreamValidatedCommit),
+      comparison,
     };
   }
 
@@ -363,7 +380,7 @@ export function listingCheckState(plugin) {
     statusLabel: "Status unknown",
     statusTone: "is-caution",
     commitLabel: "Last compatible",
-    checkedCommit: plugin?.upstreamValidatedCommit,
+    checkedCommit: fullCommit(plugin?.upstreamValidatedCommit),
     lastSuccessfulAt: plugin?.upstreamValidatedAt,
     comparison: "unknown",
   };

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-19">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-20">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260820-22"></script>
+    <script type="module" src="assets/js/develop.js?v=20260820-23"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-19">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260820-20">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260820-22"></script>
+    <script type="module" src="assets/js/app.js?v=20260820-23"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-19">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-20">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -30,12 +30,12 @@
         </main>
       </div>
       <aside class="right-aside">
-        <div class="aside-block"><span class="aside-title">On this page</span><a class="aside-link active" href="#overview">Overview</a><a class="aside-link" id="aside-install-link" href="#install">Install</a><a class="aside-link" href="#terms">Terms of Use</a></div>
+        <div class="aside-block"><span class="aside-title">On this page</span><a class="aside-link active" href="#overview">Overview</a><a class="aside-link" id="aside-install-link" href="#install">Install</a><a class="aside-link" id="aside-verification-link" href="#verification" hidden>Verification status</a><a class="aside-link" id="aside-security-link" href="#security" hidden>Security Notice</a><a class="aside-link" href="#terms">Terms of Use</a></div>
         <div class="aside-block"><span class="aside-title">Metadata</span><dl class="aside-meta"><div><dt>Availability</dt><dd id="aside-status">—</dd></div><div id="aside-verification-row"><dt>Verification</dt><dd id="aside-verification">—</dd></div><div><dt>Version</dt><dd id="aside-version">—</dd></div><div><dt>License</dt><dd id="aside-license">—</dd></div><div><dt>Owner</dt><dd id="aside-owner">—</dd></div></dl></div>
       </aside>
     </div>
-    <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install">Install</a><a href="publish.html">Publish</a></nav>
+    <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260820-22"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260820-23"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-19">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-20">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260820-22"></script>
+    <script type="module" src="assets/js/publish.js?v=20260820-23"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -496,8 +496,15 @@ test("plugin cards retain their existing verification display", () => {
   assert.equal(pluginVerificationState({ builtIn: true }), null);
 });
 
-test("plugin details distinguish snapshots from unverified updates", () => {
-  assert.deepEqual(pluginVerificationDetailState({ verificationStatus: "verified" }), {
+test("plugin details distinguish exact snapshots from unverified updates", () => {
+  const listingCommit = "a".repeat(40);
+  assert.deepEqual(pluginVerificationDetailState({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCommit: listingCommit,
+    listingValidatedCommit: listingCommit,
+    upstreamValidatedCommit: listingCommit,
+  }), {
     status: "verified",
     coverage: "snapshot-verified",
     label: "Snapshot verified",
@@ -506,6 +513,10 @@ test("plugin details distinguish snapshots from unverified updates", () => {
   });
   assert.deepEqual(pluginVerificationDetailState({
     verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCommit: listingCommit,
+    listingValidatedCommit: listingCommit,
+    upstreamValidatedCommit: listingCommit,
     verificationMethod: "maintainer-reviewed",
   }), {
     status: "verified",
@@ -518,7 +529,8 @@ test("plugin details distinguish snapshots from unverified updates", () => {
     verificationStatus: "unverified",
     verificationSnapshotStatus: "verified",
     verificationCoverage: "update-unverified",
-    verificationCommit: "a".repeat(40),
+    verificationCommit: listingCommit,
+    listingValidatedCommit: listingCommit,
     upstreamObservedCommit: "b".repeat(40),
   }), {
     status: "unverified",
@@ -526,6 +538,18 @@ test("plugin details distinguish snapshots from unverified updates", () => {
     label: "Snapshot verified. Update unverified",
     markerLabels: ["Snapshot verified", "Update unverified"],
     explanation: "The current upstream commit differs from the verified snapshot. The update and mutable upstream install command are not covered by that verification.",
+  });
+  assert.deepEqual(pluginVerificationDetailState({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCommit: "b".repeat(40),
+    listingValidatedCommit: listingCommit,
+  }), {
+    status: "unverified",
+    coverage: "unverified",
+    label: "Unverified",
+    markerLabels: ["Unverified"],
+    explanation: "No current verification record is available for the listed snapshot. This does not mean the plugin is malicious.",
   });
   assert.deepEqual(pluginVerificationDetailState({ verificationStatus: "unverified" }), {
     status: "unverified",
@@ -535,6 +559,7 @@ test("plugin details distinguish snapshots from unverified updates", () => {
     explanation: "No current verification record is available for the listed snapshot. This does not mean the plugin is malicious.",
   });
   assert.equal(pluginVerificationDetailState({ builtIn: true }), null);
+  assert.equal(pluginVerificationDetailState({ repositoryLayout: "suite" }), null);
 });
 
 test("verification filters match only exact eligible catalog statuses", () => {
@@ -684,12 +709,12 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260820-22");
+  assert.equal(keys[0], "20260820-23");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
   assert.equal(new Set(styleKeys).size, 1);
-  assert.equal(styleKeys[0], "20260820-19");
+  assert.equal(styleKeys[0], "20260820-20");
   const faviconKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/favicon\.svg\?v=([^"']+)/)?.[1]);
   assert.ok(faviconKeys.every(Boolean));
@@ -787,22 +812,29 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.security, /private vulnerability reporting form[\s\S]*security\/advisories\/new[\s\S]*Do not disclose credentials, exploit details, personal information, or other sensitive material in a public issue[\s\S]*may suspend or remove a listing/);
   assert.match(files.plugin, /<title>Plugin Details \| Omarchy Plugins<\/title>/);
   assert.match(files.plugin, /class="skip-link" href="#plugin-detail"/);
-  assert.match(files.plugin, /href="#terms">Terms of Use<\/a>/);
+  assert.match(files.plugin, /id="aside-verification-link" href="#verification" hidden>Verification status<\/a>[\s\S]*id="aside-security-link" href="#security" hidden>Security Notice<\/a>[\s\S]*href="#terms">Terms of Use<\/a>/);
+  assert.match(files.plugin, /id="mobile-install-link" href="#install" data-section-ids="install verification security">Install<\/a>/);
   assert.doesNotMatch(files.plugin, /href="#trust"|Trust & source/);
-  assert.match(files.pluginJs, /class="callout prominent-callout install-security-note"[\s\S]*<strong>Security Notice<\/strong>[\s\S]*clones the repository’s current HEAD[\s\S]*not bound to the marketplace’s verified snapshot[\s\S]*Third-party plugins run as unsandboxed code[\s\S]*not a security audit or guarantee[\s\S]*report suspicious plugins ASAP/);
-  assert.match(files.pluginJs, /class="placeholder-install verification-status-note"><strong>Verification status<\/strong><ul class="verification-status-list">\$\{snapshotNotice\}\$\{updateNotice\}\$\{contributorAction\}<\/ul>/);
-  assert.match(files.pluginJs, /snapshotNotice[\s\S]*verification-snapshot[\s\S]*Snapshot verified:<\/strong> Marketplace verification covers only the exact commit/);
+  assert.match(files.pluginJs, /const securityContext = plugin\.upstreamCheckStatus === "failed"[\s\S]*compatibility has not been confirmed[\s\S]*command[\s\S]*clones the repository’s current HEAD[\s\S]*pluginStatus === "Manual setup"[\s\S]*Manual installation follows the upstream project’s instructions/);
+  assert.match(files.pluginJs, /class="callout prominent-callout install-security-note"[\s\S]*<strong id="security-notice-title">Security Notice<\/strong>[\s\S]*\$\{securityContext\}[\s\S]*Third-party plugins run as unsandboxed code[\s\S]*not a security audit or guarantee[\s\S]*report suspicious plugins ASAP/);
+  assert.match(files.pluginJs, /const verificationStatusSection = isThirdPartyListing[\s\S]*<section class="detail-section" id="verification"><h2>Verification status<\/h2><div class="placeholder-install verification-status-note"><ul class="verification-status-list">\$\{snapshotNotice\}\$\{updateNotice\}\$\{contributorAction\}<\/ul><\/div><\/section>/);
+  assert.match(files.pluginJs, /snapshotNotice[\s\S]*verification-snapshot[\s\S]*Snapshot verified:<\/strong> Marketplace verification covers only the exact commit[\s\S]*verification-unverified[\s\S]*Snapshot unverified:<\/strong> This listed commit has not been verified/);
   assert.match(files.pluginJs, /updateNotice[\s\S]*verification-update[\s\S]*Update unverified:<\/strong> The latest upstream changes have not been verified/);
-  assert.match(files.pluginJs, /contributorAction[\s\S]*verification-contributor-action"><strong>Contributor action:<\/strong> Submit the new exact commit[\s\S]*plugin verification form/);
+  assert.match(files.pluginJs, /contributorAction[\s\S]*Submit the new exact commit[\s\S]*Submit the exact listed commit[\s\S]*plugin verification form/);
+  assert.match(files.pluginJs, /const securityNoticeSection = installSecurityNotice[\s\S]*<section class="detail-section security-notice-section" id="security" aria-labelledby="security-notice-title">\$\{installSecurityNotice\}<\/section>/);
+  assert.match(files.pluginJs, /!installAvailable[\s\S]*class="placeholder-install"[\s\S]*: `\$\{commandPanel\}\$\{installNote\}`[\s\S]*id="install"[\s\S]*\$\{verificationStatusSection\}[\s\S]*\$\{securityNoticeSection\}[\s\S]*id="terms"/);
+  assert.match(files.pluginJs, /class="detail-section\$\{isThirdPartyListing \? " detail-section-before-verification" : ""\}" id="install"/);
+  assert.match(files.pluginJs, /#aside-verification-link[\s\S]*hidden = !content\.querySelector\("#verification"\)[\s\S]*#aside-security-link[\s\S]*hidden = !content\.querySelector\("#security"\)/);
   assert.doesNotMatch(files.pluginJs, /verification-action-prompt/);
   assert.match(files.pluginJs, /issues\/new\?template=verify-plugin\.yml/);
   assert.doesNotMatch(files.pluginJs, /update-plugin\.yml/);
   assert.match(files.pluginJs, /security\/advisories\/new/);
-  assert.match(files.pluginJs, /const displayedInstallNote = plugin\.installAvailable && plugin\.repositoryLayout === "root-plugin"\s*\? ""[\s\S]*const installNote = displayedInstallNote\s*\? `<p class="install-note">\$\{escapeHtml\(displayedInstallNote\)\}<\/p>`\s*:\s*""/);
+  assert.match(files.pluginJs, /const displayedInstallNote = installAvailable && plugin\.repositoryLayout === "root-plugin"\s*\? ""[\s\S]*const installNote = displayedInstallNote\s*\? `<p class="install-note">\$\{escapeHtml\(displayedInstallNote\)\}<\/p>`\s*:\s*""/);
   assert.doesNotMatch(files.pluginJs, /Mutable upstream installation|Omarchy clones the current upstream repository, validates it locally/);
   assert.match(files.pluginJs, /function safeGitHubWebUrl\(value\)[\s\S]*url\.protocol !== "https:"[\s\S]*url\.hostname !== "github\.com"[\s\S]*return url\.href/);
   assert.match(files.pluginJs, /const repositoryReleaseUrl = safeGitHubWebUrl\(plugin\.repositoryRelease\?\.url\)[\s\S]*plugin\.repositoryRelease\?\.tag && repositoryReleaseUrl[\s\S]*: "No release tag"/);
   assert.match(files.pluginJs, /<dt>Last checked<\/dt>[\s\S]*<dt>Repository release<\/dt><dd>\$\{repositoryRelease\}<\/dd>[\s\S]*\$\{check\.commitLabel\}/);
+  assert.match(files.pluginJs, /<dt>\$\{snapshotVerified \? "Verified snapshot" : "Listing snapshot"\}[\s\S]*snapshotVerified \? "View verified snapshot" : "View listing snapshot"/);
   assert.doesNotMatch(files.pluginJs, /terms-source-note"><strong>Repository release|does not replace this plugin’s manifest version/);
   assert.match(files.pluginJs, /<section class="detail-section" id="terms"><h2>Terms of Use<\/h2>/);
   assert.match(files.pluginJs, /if \(currentHashId\(\) === "trust"\) \{[\s\S]*url\.hash = "terms";[\s\S]*history\.replaceState\(history\.state, "", url\)/);
@@ -970,8 +1002,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.pluginJs, /document\.title = `\$\{plugin\.name\} \| Omarchy Plugins`/);
   assert.match(files.pluginJs, /<section class="listing-checks" aria-labelledby="listing-checks-title">/);
   assert.match(files.pluginJs, /sectionSelector: "#detail-content \.plugin-detail-article > \[id\]"/);
-  assert.match(files.pluginJs, /Compatibility[\s\S]*Last checked[\s\S]*check\.commitLabel[\s\S]*verificationSnapshotStatus === "verified"[\s\S]*Verified snapshot[\s\S]*Listing snapshot[\s\S]*Branch[\s\S]*Upstream changes/);
-  assert.match(files.pluginJs, /\/compare\/\$\{plugin\.listingValidatedCommit\}\.\.\.\$\{plugin\.upstreamObservedCommit\}/);
+  assert.match(files.pluginJs, /Compatibility[\s\S]*Last checked[\s\S]*check\.commitLabel[\s\S]*snapshotVerified \? "Verified snapshot" : "Listing snapshot"[\s\S]*Branch[\s\S]*Upstream changes/);
+  assert.match(files.pluginJs, /\/compare\/\$\{comparedCommits\.listingCommit\}\.\.\.\$\{comparedCommits\.upstreamCommit\}/);
   assert.doesNotMatch(files.pluginJs, /Listing provenance/);
   assert.match(files.index, /class="market-hero-ray"[\s\S]*<canvas width="400" height="300" aria-hidden="true"><\/canvas>/);
   assert.match(files.app, /function setupHeroRay\(\)/);
@@ -1117,10 +1149,14 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.aside-meta \.aside-verification\s*\{[^}]*display: flex; max-width: 100%; margin-left: auto; align-items: flex-end;[\s\S]*flex-direction: column; gap: 4px;/);
   assert.doesNotMatch(styles, /\.aside-meta div:has\(\.aside-verification\)|\.aside-meta \.aside-verification \.card-verification-tooltip|\.aside-verification \.card-verification-marker/);
   assert.match(styles, /\.detail-verification \.card-verification-marker\.is-snapshot \{ color: var\(--stable\); \}/);
-  assert.match(styles, /\.verification-status-note > strong,[\s\S]*\.verification-status-note \.verification-contributor-action strong \{ color: var\(--text\); \}/);
+  assert.match(styles, /\.detail-section-before-verification > \.command-panel:last-child \{ margin-bottom: 0; \}/);
+  assert.match(styles, /\.detail-section#install \+ \.detail-section#verification \{ padding-top: 0; \}/);
+  assert.match(styles, /\.detail-section#install \+ \.detail-section#verification::before \{ content: none; \}/);
+  assert.match(styles, /\.verification-status-note \.verification-contributor-action strong \{ color: var\(--text\); \}/);
+  assert.match(styles, /\.security-notice-section \.install-security-note \{ margin: 0; \}/);
   assert.match(styles, /\.verification-status-note \.verification-snapshot strong \{ color: var\(--stable\); \}/);
-  assert.match(styles, /\.verification-status-note \.verification-update strong \{ color: var\(--accent\); \}/);
-  assert.match(styles, /\.verification-status-list \{ padding: 0; margin: 4px 0 0; list-style: none; \}/);
+  assert.match(styles, /\.verification-status-note \.verification-update strong,[\s\S]*\.verification-status-note \.verification-unverified strong \{ color: var\(--accent\); \}/);
+  assert.match(styles, /\.verification-status-list \{ padding: 0; margin: 0; list-style: none; \}/);
   assert.match(styles, /\.verification-status-list li\s*\{[^}]*position: relative; padding-left: 24px; margin: 8px 0;[^}]*font-size: 15px; line-height: 1\.72;/);
   assert.match(styles, /\.verification-status-list li::before\s*\{[^}]*top: \.62em; left: 8px; width: 6px; height: 6px;[\s\S]*background: var\(--accent\); content: "";/);
   assert.match(styles, /\.detail-verification \.card-verification-trigger\s*\{[^}]*height: auto; align-items: flex-start; flex-direction: column; gap: 4px;/);

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -176,6 +176,62 @@ test("listing checks distinguish passed, failed, and unreachable snapshots", () 
   });
 });
 
+test("listing checks normalize and fail closed on stale commit metadata", () => {
+  const listingCommit = "a".repeat(40);
+  const changedCommit = "b".repeat(40);
+
+  assert.deepEqual(listingCheckState({
+    listingValidatedCommit: listingCommit.toUpperCase(),
+    upstreamObservedCommit: listingCommit,
+    upstreamValidatedCommit: changedCommit,
+    upstreamCheckStatus: "passed",
+  }), {
+    statusLabel: "Passed",
+    statusTone: "is-passed",
+    commitLabel: "Checked commit",
+    checkedCommit: listingCommit,
+    comparison: "unchanged",
+  });
+
+  assert.deepEqual(listingCheckState({
+    listingValidatedCommit: listingCommit,
+    upstreamValidatedCommit: changedCommit,
+    upstreamCheckStatus: "passed",
+  }), {
+    statusLabel: "Passed",
+    statusTone: "is-passed",
+    commitLabel: "Checked commit",
+    checkedCommit: changedCommit,
+    comparison: "changed",
+  });
+
+  assert.deepEqual(listingCheckState({
+    listingValidatedCommit: listingCommit,
+    upstreamObservedCommit: "malformed",
+    upstreamValidatedCommit: changedCommit.toUpperCase(),
+    upstreamCheckStatus: "passed",
+  }), {
+    statusLabel: "Passed",
+    statusTone: "is-passed",
+    commitLabel: "Checked commit",
+    checkedCommit: changedCommit,
+    comparison: "changed",
+  });
+
+  assert.deepEqual(listingCheckState({
+    listingValidatedCommit: listingCommit,
+    upstreamObservedCommit: "malformed",
+    upstreamValidatedCommit: "also-malformed",
+    upstreamCheckStatus: "passed",
+  }), {
+    statusLabel: "Passed",
+    statusTone: "is-passed",
+    commitLabel: "Checked commit",
+    checkedCommit: "",
+    comparison: "unknown",
+  });
+});
+
 test("catalog pagination clamps pages and exposes stable boundaries", () => {
   assert.deepEqual(paginationState(9, 1), {
     page: 1,

--- a/test/plugin-detail-rendering.test.js
+++ b/test/plugin-detail-rendering.test.js
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { detailTemplate } from "../site/assets/js/plugin.js";
+
+const verifiedCommit = "1".repeat(40);
+const upstreamCommit = "2".repeat(40);
+
+function communityPlugin(overrides = {}) {
+  return {
+    id: "example.community-plugin",
+    name: "Community Plugin",
+    initials: "CP",
+    category: "Desktop",
+    author: "Example Maintainer",
+    description: "A community plugin used by rendering tests.",
+    tags: ["desktop"],
+    accent: "lime",
+    version: "1.0.0",
+    license: "MIT",
+    sourceType: "community",
+    builtIn: false,
+    placeholder: false,
+    installAvailable: true,
+    installCommand: "omarchy plugin add https://github.com/example/community-plugin.git --enable",
+    installNote: "",
+    status: "Available",
+    repositoryLayout: "root-plugin",
+    verificationStatus: "unverified",
+    verificationSnapshotStatus: "unverified",
+    verificationCoverage: "unverified",
+    repo: "https://github.com/example/community-plugin",
+    sourceUrl: "https://github.com/example/community-plugin",
+    ...overrides,
+  };
+}
+
+function render(overrides = {}) {
+  return detailTemplate(communityPlugin(overrides), { views: 0, copies: 0, hearts: 0 });
+}
+
+function assertCommunitySectionOrder(html) {
+  const install = html.indexOf('id="install"');
+  const verification = html.indexOf('id="verification"');
+  const security = html.indexOf('id="security"');
+  const terms = html.indexOf('id="terms"');
+  assert.ok(install >= 0 && verification > install && security > verification && terms > security);
+}
+
+test("installable unverified plugin details render exact snapshot and mutable-install warnings", () => {
+  const html = render();
+
+  assertCommunitySectionOrder(html);
+  assert.match(html, /<h2>Install<\/h2>/);
+  assert.match(html, /Snapshot unverified:<\/strong> This listed commit has not been verified\./);
+  assert.match(html, /Contributor action:<\/strong> Submit the exact listed commit/);
+  assert.match(html, /This Omarchy command clones the repository’s current HEAD\./);
+  assert.doesNotMatch(html, /Manual installation follows the upstream project’s instructions\./);
+  assert.match(html, /<section class="detail-section security-notice-section" id="security" aria-labelledby="security-notice-title">[\s\S]*<strong id="security-notice-title">Security Notice<\/strong>/);
+});
+
+test("manual setup plugin details render the manual-install security context", () => {
+  const html = render({
+    installAvailable: false,
+    installCommand: "",
+    installNote: "Follow the upstream installation instructions.",
+    status: "Manual setup",
+  });
+
+  assertCommunitySectionOrder(html);
+  assert.match(html, /<h2>Availability<\/h2>/);
+  assert.match(html, /<strong>Manual setup<\/strong>/);
+  assert.match(html, /Snapshot unverified:<\/strong> This listed commit has not been verified\./);
+  assert.match(html, /Manual installation follows the upstream project’s instructions\./);
+  assert.doesNotMatch(html, /This Omarchy command clones the repository’s current HEAD\./);
+});
+
+test("verified plugin details render only the exact verified snapshot", () => {
+  const html = render({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "snapshot-verified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    listingValidatedAt: "2026-08-20T12:00:00.000Z",
+    listingValidatedBranch: "main",
+    upstreamCheckStatus: "passed",
+    upstreamValidatedCommit: verifiedCommit,
+    upstreamObservedCommit: verifiedCommit,
+    upstreamObservedBranch: "main",
+    upstreamCheckedAt: "2026-08-20T12:00:00.000Z",
+  });
+
+  assertCommunitySectionOrder(html);
+  assert.match(html, /Snapshot verified:<\/strong> Marketplace verification covers only the exact commit/);
+  assert.match(html, new RegExp(`<dt>Verified snapshot<\\/dt><dd><a href="https:\\/\\/github\\.com\\/example\\/community-plugin\\/commit\\/${verifiedCommit}"[\\s\\S]*<code>1111111<\\/code>`));
+  assert.doesNotMatch(html, /Snapshot unverified:|Update unverified:|Contributor action:/);
+});
+
+test("changed upstream details preserve the verified snapshot and flag the update", () => {
+  const html = render({
+    verificationStatus: "unverified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "update-unverified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    listingValidatedAt: "2026-08-20T12:00:00.000Z",
+    listingValidatedBranch: "main",
+    upstreamCheckStatus: "passed",
+    upstreamValidatedCommit: upstreamCommit,
+    upstreamObservedCommit: upstreamCommit,
+    upstreamObservedBranch: "main",
+    upstreamCheckedAt: "2026-08-21T12:00:00.000Z",
+  });
+
+  assertCommunitySectionOrder(html);
+  assert.match(html, /Snapshot verified:<\/strong>/);
+  assert.match(html, /Update unverified:<\/strong> The latest upstream changes have not been verified\./);
+  assert.match(html, /Contributor action:<\/strong> Submit the new exact commit/);
+});
+
+test("observed commit drift overrides stale snapshot coverage", () => {
+  const html = render({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "snapshot-verified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    upstreamObservedCommit: upstreamCommit,
+  });
+
+  assert.match(html, /Snapshot verified:<\/strong>/);
+  assert.match(html, /Update unverified:<\/strong> The latest upstream changes have not been verified\./);
+  assert.match(html, /Contributor action:<\/strong> Submit the new exact commit/);
+});
+
+test("detail checks use a valid fallback when observed commit metadata is malformed", () => {
+  const html = render({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "snapshot-verified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    upstreamObservedCommit: "malformed",
+    upstreamValidatedCommit: upstreamCommit.toUpperCase(),
+    upstreamCheckStatus: "passed",
+  });
+
+  assert.match(html, /Update unverified:<\/strong>/);
+  assert.match(html, new RegExp(`/compare/${verifiedCommit}\\.\\.\\.${upstreamCommit}`));
+  assert.doesNotMatch(html, /No changes detected|Could not determine/);
+});
+
+test("detail checks fail closed when current commit metadata is invalid", () => {
+  const html = render({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "snapshot-verified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    upstreamObservedCommit: "malformed",
+    upstreamValidatedCommit: "also-malformed",
+    upstreamCheckStatus: "passed",
+  });
+
+  assert.match(html, /Update unverified:<\/strong>/);
+  assert.match(html, /Could not determine/);
+  assert.doesNotMatch(html, /View changes|No changes detected/);
+});
+
+test("compatibility failures override stale manual status and install commands", () => {
+  const html = render({
+    installAvailable: false,
+    installCommand: "omarchy plugin add https://github.com/example/stale.git --enable",
+    installNote: "The latest compatibility check failed.",
+    status: "Manual setup",
+    upstreamCheckStatus: "failed",
+  });
+
+  assertCommunitySectionOrder(html);
+  assert.match(html, /<strong>Compatibility failed<\/strong>/);
+  assert.match(html, /Marketplace installation is unavailable because compatibility has not been confirmed\./);
+  assert.match(html, /Installation through another method is not bound to the marketplace’s listed or verified snapshot/);
+  assert.doesNotMatch(html, /Manual installation follows the upstream project’s instructions\.|data-install-copy/);
+});
+
+test("mismatched snapshot commits fail closed as unverified", () => {
+  const html = render({
+    verificationStatus: "verified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "snapshot-verified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: upstreamCommit,
+  });
+
+  assert.match(html, /Snapshot unverified:<\/strong>/);
+  assert.match(html, /Contributor action:<\/strong> Submit the exact listed commit/);
+  assert.match(html, /<dt>Listing snapshot<\/dt>/);
+  assert.doesNotMatch(html, /Snapshot verified:|Update unverified:|<dt>Verified snapshot<\/dt>/);
+});
+
+test("suite listings do not offer the unsupported verification workflow", () => {
+  const html = render({
+    installAvailable: false,
+    installCommand: "",
+    installNote: "Follow the suite installation instructions.",
+    status: "Manual setup",
+    repositoryLayout: "suite",
+    verificationStatus: "unverified",
+    verificationSnapshotStatus: "verified",
+    verificationCoverage: "update-unverified",
+    verificationCommit: verifiedCommit,
+    listingValidatedCommit: verifiedCommit,
+    upstreamObservedCommit: upstreamCommit,
+  });
+
+  assert.match(html, /Verification unavailable:<\/strong> Suite listings are outside the plugin verification workflow\./);
+  assert.doesNotMatch(html, /Snapshot verified:|Snapshot unverified:|Update unverified:|Contributor action:|plugin verification form|detail-verification/);
+});


### PR DESCRIPTION
## Summary

- show a dedicated verification-status section on community plugin detail pages, including manual-setup and normally installable plugins
- distinguish exact verified snapshots, unverified snapshots, and unverified upstream updates without changing marketplace cards
- provide install-mode-specific security notices and responsive section navigation
- fail closed on stale, malformed, or mismatched commit metadata and keep suite listings outside the plugin verification workflow
- add behavioral rendering and commit-normalization regression coverage

## Validation

- `npm test` — 180/180 passed
- JavaScript syntax checks passed
- `git diff --check` passed
- desktop and mobile browser sandbox checks passed with 0 errors
- two independent final reviews reported zero findings
