### PR TITLE
Add Terminal Shop plugin listing

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -31175,6 +31175,40 @@
           "manifestPath": "manifest.json"
         }
       }
+    },
+    {
+      "repo": "https://github.com/dl-alexandre/terminal-shop-omarchy",
+      "type": "plugin-source",
+      "addedAt": "2026-08-21",
+      "listedAt": "2026-08-21T14:57:11.425Z",
+      "listingValidatedCommit": "18877307e6f39a87e12d7adb36c71c6acaed610a",
+      "listingValidatedAt": "2026-08-21T19:50:04.000Z",
+      "listingValidatedBranch": "main",
+      "automatedSecurityBaseline": {
+        "schemaVersion": 1,
+        "version": "3",
+        "repository": "dl-alexandre/terminal-shop-omarchy",
+        "pluginIds": [
+          "terminal.shop"
+        ],
+        "commit": "18877307e6f39a87e12d7adb36c71c6acaed610a",
+        "checkedAt": "2026-08-21T19:50:04.000Z",
+        "outcome": "passed",
+        "enforcementMode": "selective",
+        "findings": [],
+        "capabilities": []
+      },
+      "plugins": {
+        "terminal.shop": {
+          "category": "Productivity",
+          "tags": [
+            "bar",
+            "quickshell",
+            "security"
+          ],
+          "manifestPath": "manifest.json"
+        }
+      }
     }
   ],
   "builtInSources": [


### PR DESCRIPTION
## Summary

- add Terminal Shop (`terminal.shop`) to the curated plugin registry
- pin the listing to the validated snapshot `18877307e6f39a87e12d7adb36c71c6acaed610a`
- classify it as a Productivity bar widget with bar, quickshell, and security tags

## Verification

- marketplace validation and automated security baseline passed on the previous fixed snapshot
- response-body limit fix is merged in upstream `main`
- 8 unit tests, Python compilation, JSON validation, and `git diff --check` pass

Closes #1240