### PR TITLE
Add plugin documentation links

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,14 +24,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260820-23";
+} from "./shared.js?v=20260822-24";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260820-23";
+} from "./engagement.js?v=20260822-24";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -54,7 +54,7 @@ import {
   searchTermKey,
   searchTokens,
   selectSearchCompletions,
-} from "./search.js?v=20260820-23";
+} from "./search.js?v=20260822-24";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set(["bar", "hyprland", "quickshell"]);

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260820-23";
+} from "./shared.js?v=20260822-24";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -20,7 +20,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260820-23";
+} from "./shared.js?v=20260822-24";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -28,7 +28,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260820-23";
+} from "./engagement.js?v=20260822-24";
 
 function safeGitHubWebUrl(value) {
   try {
@@ -44,6 +44,15 @@ function safeGitHubWebUrl(value) {
   } catch {
     return "";
   }
+}
+
+function safeGitHubReadmeUrl(value) {
+  const safeUrl = safeGitHubWebUrl(value);
+  if (!safeUrl) return "";
+  const url = new URL(safeUrl);
+  url.search = "";
+  url.hash = "readme";
+  return url.href;
 }
 
 function marketplaceInstallAvailable(plugin) {
@@ -138,6 +147,10 @@ export function detailTemplate(plugin, engagement, {
   const isThirdPartyListing = plugin.sourceType === "community"
     && !plugin.builtIn
     && !plugin.placeholder;
+  const documentationUrl = isThirdPartyListing ? safeGitHubReadmeUrl(plugin.repo) : "";
+  const documentationAction = documentationUrl
+    ? ` <a class="button" href="${escapeHtml(documentationUrl)}" target="_blank" rel="noreferrer">Read documentation ↗</a>`
+    : "";
   const verificationEligible = isThirdPartyListing && plugin.repositoryLayout !== "suite";
   const canRequestVerification = verificationEligible;
   const snapshotVerified = verificationEligible && hasExactVerificationSnapshot(plugin);
@@ -271,7 +284,7 @@ export function detailTemplate(plugin, engagement, {
       <section class="detail-section${isThirdPartyListing ? " detail-section-before-verification" : ""}" id="install"><h2>${plugin.builtIn ? escapeHtml(plugin.officialCommandLabel) : availabilityHeading}</h2>${install}</section>
       ${verificationStatusSection}
       ${securityNoticeSection}
-      <section class="detail-section" id="terms"><h2>Terms of Use</h2>${sourceNote}${provenance}<p style="margin-top:18px"><a class="button primary" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noreferrer">View source ↗</a></p></section>
+      <section class="detail-section" id="terms"><h2>Terms of Use</h2>${sourceNote}${provenance}<p class="submit-action"><a class="button primary" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noreferrer">View source ↗</a>${documentationAction}</p></section>
     </article>`;
 }
 

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260820-23";
+} from "./shared.js?v=20260822-24";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260820-23"></script>
+    <script type="module" src="assets/js/develop.js?v=20260822-24"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260820-23"></script>
+    <script type="module" src="assets/js/app.js?v=20260822-24"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -36,6 +36,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260820-23"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260822-24"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260820-23"></script>
+    <script type="module" src="assets/js/publish.js?v=20260822-24"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -709,7 +709,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260820-23");
+  assert.equal(keys[0], "20260822-24");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));

--- a/test/plugin-detail-rendering.test.js
+++ b/test/plugin-detail-rendering.test.js
@@ -58,6 +58,16 @@ test("installable unverified plugin details render exact snapshot and mutable-in
   assert.match(html, /<section class="detail-section security-notice-section" id="security" aria-labelledby="security-notice-title">[\s\S]*<strong id="security-notice-title">Security Notice<\/strong>/);
 });
 
+test("community plugin details link directly to the repository documentation", () => {
+  const html = render();
+
+  assert.match(html, /href="https:\/\/github\.com\/example\/community-plugin#readme" target="_blank" rel="noreferrer">Read documentation ↗<\/a>/);
+  assert.match(html, /<p class="submit-action"><a class="button primary"[\s\S]*View source ↗<\/a> <a class="button"/);
+
+  const unsafe = render({ repo: "https://example.com/community-plugin" });
+  assert.doesNotMatch(unsafe, /Read documentation/);
+});
+
 test("manual setup plugin details render the manual-install security context", () => {
   const html = render({
     installAvailable: false,


### PR DESCRIPTION
## Summary

- add a “Read documentation” action to third-party plugin detail pages
- restrict the link to validated GitHub repositories and point it at the repository README
- update the coupled JavaScript cache key and add rendering coverage

## Validation

- `npm test` (181 tests)
- `git diff --check`
- responsive review at 320, 375, 760, 761, 800, 850, 879, 880, 1024, and 1440 px
- reviewed dark and light themes; no horizontal overflow or action overlap
