### PR TITLE
Downgrade oversized non-executable files to a review capability instead of a hard failure

### DIFF
--- a/scripts/security-baseline-analysis.mjs
+++ b/scripts/security-baseline-analysis.mjs
@@ -1,6 +1,6 @@
 import { parseGitHubRepository } from "./github-repository.mjs";
 import { SecurityBaselineError } from "./security-baseline-error.mjs";
-import { securitySnapshotFileLimit } from "./security-baseline-limits.mjs";
+import { securityFileByteLimit, securitySnapshotFileLimit } from "./security-baseline-limits.mjs";
 import { assertFullCommitSha } from "./security-github-snapshot.mjs";
 import { isRootReadme } from "./security-baseline-scope.mjs";
 import {
@@ -34,6 +34,7 @@ export function referencedSudoersPolicyPaths(files, tree) {
   const referenced = new Set();
   for (const file of files.filter((entry) => (
     !entry.binary
+    && !entry.oversized
     && (isShellRuntimePath(entry.path) || isExecutableTextFile(entry))
     && invokesSudoersModification(entry.content || "")
   ))) {
@@ -1295,7 +1296,7 @@ function privilegedTempProcessFinding(file) {
 
 export function detectUnsafeRemoteExecution(files, submissionRepository = "") {
   const findings = [];
-  const preparedFiles = files.filter((entry) => !entry.binary).map((file) => ({
+  const preparedFiles = files.filter((entry) => !entry.binary && !entry.oversized).map((file) => ({
     ...file,
     ...(isRootReadme(file.path)
       ? { documentedRepositories: [...commandRemoteRepositories(file)] }
@@ -1383,7 +1384,18 @@ export function detectElevatedCapabilities(files, submissionRepository = "") {
       }],
     });
   }
-  for (const file of expandedSecurityFiles((files || []).filter((entry) => !entry.binary))) {
+  for (const oversized of (files || []).filter((entry) => entry.oversized)) {
+    capabilities.push({
+      id: "oversized-unscanned-file",
+      ...capabilityCatalog["oversized-unscanned-file"],
+      evidence: [{
+        path: oversized.path,
+        line: 1,
+        snippet: `File exceeds the ${securityFileByteLimit}-byte static scan limit (${oversized.size} bytes)`,
+      }],
+    });
+  }
+  for (const file of expandedSecurityFiles((files || []).filter((entry) => !entry.binary && !entry.oversized))) {
     const installer = installerEvidence(file);
     if (installer) capabilities.push({ id: "installer", ...capabilityCatalog.installer, evidence: [installer] });
     if (isSudoersPolicyFile(file)) {

--- a/scripts/security-baseline-policy.mjs
+++ b/scripts/security-baseline-policy.mjs
@@ -91,6 +91,10 @@ export const securityBaselineCapabilityCatalog = Object.freeze({
     title: "Bundled executable binary",
     why: "The repository includes an executable binary that this deterministic source scan cannot inspect.",
   }),
+  "oversized-unscanned-file": Object.freeze({
+    title: "Oversized file skipped by the static scan",
+    why: "The file exceeds the static scan's per-file size limit, so its contents were not statically analyzed.",
+  }),
   "service-management": Object.freeze({
     title: "Service management",
     why: "The plugin can inspect or change a system or user service lifecycle.",

--- a/scripts/security-baseline-scope.mjs
+++ b/scripts/security-baseline-scope.mjs
@@ -284,11 +284,11 @@ export async function resolveSecuritySnapshot(repoUrl, commitSha, options = {}) 
       `The repository has more than ${securitySnapshotFileLimit} relevant text files`,
     );
   }
-  const declaredTextSize = entries.reduce((sum, entry) => (
-    sum + (entry.mode === "100755" && Number(entry.size || 0) > securityFileByteLimit
-      ? securityBinaryProbeByteLimit
-      : Number(entry.size || 0))
-  ), 0);
+  const declaredTextSize = entries.reduce((sum, entry) => {
+    const size = Number(entry.size || 0);
+    if (size <= securityFileByteLimit) return sum + size;
+    return sum + (entry.mode === "100755" ? securityBinaryProbeByteLimit : 0);
+  }, 0);
   if (declaredTextSize > securitySnapshotByteLimit) {
     throw new SecurityBaselineError(
       "security-baseline-scan-limit",
@@ -323,7 +323,11 @@ export async function resolveSecuritySnapshot(repoUrl, commitSha, options = {}) 
       `The repository has more than ${securitySnapshotFileLimit} relevant text files`,
     );
   }
-  const referencedSize = referencedEntries.reduce((sum, entry) => sum + Number(entry.size || 0), 0);
+  const referencedSize = referencedEntries.reduce((sum, entry) => {
+    const size = Number(entry.size || 0);
+    if (size <= securityFileByteLimit) return sum + size;
+    return sum + (entry.mode === "100755" ? securityBinaryProbeByteLimit : 0);
+  }, 0);
   if (declaredTextSize + referencedSize > securitySnapshotByteLimit) {
     throw new SecurityBaselineError(
       "security-baseline-scan-limit",

--- a/scripts/security-github-snapshot.mjs
+++ b/scripts/security-github-snapshot.mjs
@@ -103,11 +103,7 @@ async function readSnapshotResponse(repository, commitSha, entry, { fetchImpl },
 export async function readSnapshotFile(repository, commitSha, entry, options) {
   if (entry.size > securityFileByteLimit) {
     if (entry.mode !== "100755") {
-      throw new SecurityBaselineError(
-        "security-baseline-scan-limit",
-        `${entry.path} exceeds the static scan file-size limit`,
-        { path: entry.path },
-      );
+      return { path: entry.path, mode: entry.mode, oversized: true, size: entry.size };
     }
     const probeResponse = await readSnapshotResponse(
       repository,

--- a/test/security-baseline.test.js
+++ b/test/security-baseline.test.js
@@ -25,6 +25,7 @@ import {
   securityBaselineErrorMarker,
   securityBaselineMarkerPrefix,
   verifiedPublicationDisposition,
+  securityFileByteLimit,
   securitySnapshotByteLimit,
   securitySnapshotFileLimit,
   serializeSecurityBaselineMarker,
@@ -1362,6 +1363,46 @@ test("executable binaries become review capabilities without exhausting text lim
     }),
     (error) => error.code === "security-baseline-unavailable",
   );
+});
+
+test("oversized non-executable vendored files become review capabilities instead of hard failures", async () => {
+  const manifest = JSON.stringify({ entryPoints: { service: "Service.qml" } });
+  const vendoredSize = securityFileByteLimit + 800 * 1024;
+  let rawFileRequests = 0;
+  const fixtureFetch = githubFixtureFetch({
+    tree: [
+      { path: "manifest.json", type: "blob", mode: "100644", size: Buffer.byteLength(manifest) },
+      { path: "Service.qml", type: "blob", mode: "100644", size: 7 },
+      { path: "vendor/three.module.js", type: "blob", mode: "100644", size: vendoredSize },
+    ],
+    contents: {
+      "manifest.json": manifest,
+      "Service.qml": "Item {}",
+      "vendor/three.module.js": "x".repeat(vendoredSize),
+    },
+  });
+  const snapshot = await resolveSubmissionSnapshot(
+    "https://github.com/example/plugin",
+    commit,
+    {
+      fetchImpl: (url, options) => {
+        if (String(url).includes("vendor/three.module.js")) rawFileRequests += 1;
+        return fixtureFetch(url, options);
+      },
+    },
+  );
+  const vendored = snapshot.files.find((entry) => entry.path === "vendor/three.module.js");
+  assert.deepEqual(vendored, {
+    path: "vendor/three.module.js",
+    mode: "100644",
+    oversized: true,
+    size: vendoredSize,
+  });
+  assert.equal(rawFileRequests, 0, "an oversized non-executable file must not be downloaded");
+  const result = buildSecurityBaseline(snapshot, { checkedAt });
+  assert.equal(result.outcome, "review-required");
+  assert.deepEqual(result.capabilities.map((capability) => capability.id), ["oversized-unscanned-file"]);
+  assert.equal(result.findings.length, 0);
 });
 
 test("the snapshot file cap accommodates the existing large plugin suites", async () => {


### PR DESCRIPTION
## Problem

Fixes #1862.

The automated security baseline hard-fails validation (`security-baseline-scan-limit`, exit code 2) whenever a submitted repo contains a single non-executable file over the 512 KB static-scan limit — even a legitimate vendored dependency. There's currently no way for such a submission to ever pass.

This is inconsistent with how the scanner already treats **executable** binaries over the same limit: those become a `bundled-executable-binary` review capability (outcome `review-required`) instead of a hard failure, because the deterministic scanner simply can't inspect binary content. A non-executable oversized file — e.g. a vendored `three.module.js` — is the same situation (content the static scanner chooses not to analyze due to size) but was wired to a hard crash instead.

## Fix

- `scripts/security-github-snapshot.mjs`: an oversized non-executable file now returns `{ path, mode, oversized: true, size }` (using only the already-trusted declared tree size — the content is never downloaded) instead of throwing.
- `scripts/security-baseline-policy.mjs`: adds an `oversized-unscanned-file` capability to the existing catalog, alongside `bundled-executable-binary`.
- `scripts/security-baseline-analysis.mjs`: `detectElevatedCapabilities` flags oversized files with the new capability; the text-scanning filters (`detectUnsafeRemoteExecution`, `expandedSecurityFiles`, `referencedSudoersPolicyPaths`) skip them the same way they already skip binaries.
- `scripts/security-baseline-scope.mjs`: the snapshot byte-budget calculation (`declaredTextSize`/`referencedSize`) no longer counts the full declared size of a skipped oversized file, since it's never downloaded (mirrors the existing treatment of oversized executables, which only count the probe size).

The remaining scan-limit guards (truncated tree, too many files, aggregate snapshot byte budget, command/shell-state expansion limits) are untouched — those bound total scan cost/complexity across the whole repo and stay hard failures. This change is narrowly about a *single file* being too large to statically inspect, which is exactly the scenario the existing binary-capability path already handles gracefully.

## Testing

- `npm test`: all 181 tests pass (180 existing + 1 new).
- Added `test/security-baseline.test.js`: "oversized non-executable vendored files become review capabilities instead of hard failures" — asserts the file is never fetched, the snapshot resolves, and the outcome is `review-required` with an `oversized-unscanned-file` capability.
- Verified live against the real submission that hit this bug (`mrcgibb9876-hash/temparchy-omarchy-plugin`, run [32638630376](https://github.com/HANCORE-linux/omarchy-plugin-marketplace/actions/runs/32638630376)): running `scripts/security-baseline.mjs` against that repo's current commit now exits 0 with outcome `review-required` and both oversized files individually flagged with path/size, instead of crashing the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)