### PR TITLE
Fix invalid install command for built-in bar-widget plugins

### DIFF
--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -947,10 +947,7 @@ function builtInKind(kinds) {
   return kinds.map((kind) => labels[kind] || kind).join(" + ");
 }
 
-function builtInCommand(id, kinds) {
-  if (kinds.includes("bar-widget")) {
-    return { command: `omarchy bar plugin add ${id}`, label: "Add to bar" };
-  }
+function builtInCommand(id) {
   return { command: `omarchy plugin enable ${id}`, label: "Enable plugin" };
 }
 
@@ -988,7 +985,7 @@ async function discoveredBuiltIns(source, context) {
     validateManifestFiles(manifest, manifestPath, context);
     if (excluded.has(manifest.id)) return null;
     const kinds = manifest.kinds.map(String);
-    const officialCommand = builtInCommand(manifest.id, kinds);
+    const officialCommand = builtInCommand(manifest.id);
     const sourceDirectory = dirname(manifestPath);
     return {
       id: manifest.id,


### PR DESCRIPTION
## Problem

The catalog's install command for built-in **bar-widget** plugins is invalid:

```
omarchy bar plugin add <id>
```

This subcommand does not exist in Omarchy — running it fails with `omarchy-bar: unknown command: plugin` (or `unknown command: bar`, depending on entry point). Reproduced today with `omarchy.media`: the site told me to run that command, and it errored. The working command for any built-in plugin, regardless of kind, is:

```
omarchy plugin enable <id>
```

(`omarchy plugin --help` lists only `add/clone/disable/enable/list/remove/update/validate`; there is no `bar` noun.)

## Fix

`builtInCommand()` no longer branches on `kinds` — every built-in gets `omarchy plugin enable <id>`. The unused `kinds` parameter and its call-site argument are removed.

## Notes

- Verified against Omarchy v4.0.0 (`omarchy plugin enable omarchy.notifications` / `omarchy.media` both succeed; `omarchy bar plugin add ...` errors).
- The generated catalog may need a rebuild after merging so the site picks up corrected commands.