### PR TITLE
Extend full catalog refresh timeout

### DIFF
--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -13,7 +13,8 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A full refresh currently takes about 50 minutes across 1,300+ sources.
+    timeout-minutes: 90
     permissions:
       contents: read
     outputs:

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1549,6 +1549,7 @@ test("automation deploys refreshed catalogs and uses listing-specific approval",
   const refreshJob = jobSource(refresh, "refresh", "publish");
   const refreshPublishJob = jobSource(refresh, "publish", "deploy");
   const refreshDeployJob = jobSource(refresh, "deploy");
+  assert.match(refreshJob, /^    timeout-minutes:[ \t]+90[ \t]*$/m);
   assert.match(refreshJob, /permissions:\s+contents: read/);
   assert.ok(refreshJob.indexOf("run: npm run build") < refreshJob.indexOf("run: npm test"));
   assert.doesNotMatch(refreshPublishJob, /npm ci|npm run build|npm test|setup-node/);


### PR DESCRIPTION
## Summary

- raise the scheduled full-catalog refresh timeout from 20 to 90 minutes
- add a regression assertion for the bounded refresh timeout

## Why

The last three scheduled full refreshes were cancelled at the 20-minute job limit while `npm run build` was still scanning the catalog. The catalog has grown from 3 community sources when the limit was introduced to more than 1,300 sources today.

A controlled Sandbox run completed the full refresh in 29 minutes and 29 seconds. A local production-data build completed in 51 minutes and 21 seconds. The 90-minute limit keeps the job bounded while providing enough headroom for current runtime variance.

The successful Sandbox artifact detected AniSync 1.2.1 as an unverified upstream update while preserving its exact verified 1.1.0 snapshot.

## Safety

- verification and scanner logic are unchanged
- least-privilege permissions and `plugin-catalog-writes` serialization are unchanged
- tested-artifact hashes, exact base-commit checks, and fail-closed publication remain unchanged
- no generated catalog or preview files are included

## Validation

- `npm test` — 205/205 passed
- YAML, syntax, whitespace, scope, ancestry, and author identity checks passed
- Sandbox runtime run `32888257171` — success; no Pages artifact, publication, deployment, or `main` mutation
- independent correctness and adversarial AppSec reviews — 0 findings
