### PR TITLE
Improve catalog search semantics

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,20 +25,21 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260826-01";
+} from "./shared.js?v=20260827-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260826-01";
+} from "./engagement.js?v=20260827-01";
 import {
   appendSearchState,
   committedTermsFromDraft,
   completionTarget,
   createSearchTerm,
   currentSearchToken,
+  foldSearchTerm,
   fuzzyScore,
   handleSearchEscape,
   inlineSearchCompletionSuffix,
@@ -51,10 +52,11 @@ import {
   readSearchState,
   removeSearchTermTypeFromDraft,
   searchKeyAction,
+  searchPhraseKey,
   searchTermDisplayValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260826-01";
+} from "./search.js?v=20260827-01";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([
@@ -190,7 +192,7 @@ function publisherLogin(plugin) {
 
 function pluginSearchText(plugin) {
   const publisher = publisherLogin(plugin);
-  return [
+  return foldSearchTerm([
     plugin.name,
     plugin.description,
     plugin.author,
@@ -200,7 +202,7 @@ function pluginSearchText(plugin) {
     plugin.category,
     plugin.kind,
     ...(plugin.tags || [])
-  ].join(" ").toLocaleLowerCase();
+  ].join(" "));
 }
 
 function pluginSearchContext(plugin) {
@@ -229,8 +231,9 @@ function pluginMatchesActiveSearch(plugin) {
     : matchesCommittedSearchTerm(term, matchContext));
   const textDraftTerms = draftTerms.filter((term) => term.type === "text");
   const typedDraftTerms = draftTerms.filter((term) => term.type !== "text");
-  const matchesTextDraft = textDraftTerms.length > 0
-    && textDraftTerms.every((term) => matchesDirectSearch(term.value, matchContext));
+  const textDraft = textDraftTerms.map((term) => term.value).join(" ");
+  const matchesTextDraft = Boolean(textDraft)
+    && matchesDirectSearch(textDraft, matchContext);
   const matchesTypedDraft = typedDraftTerms.some((term) =>
     matchesDraftSearchTerm(term, matchContext)
   );
@@ -239,13 +242,13 @@ function pluginMatchesActiveSearch(plugin) {
 
 function completionMatches(value) {
   const rawQuery = currentSearchToken(value);
-  const query = rawQuery.replace(/^@/, "").toLocaleLowerCase();
+  const query = foldSearchTerm(rawQuery.replace(/^@/, ""));
   if (!query) return [];
   const inputTokens = normalizeSearchTerm(value).split(" ");
   const pluginQueries = inputTokens.map((_, index) =>
-    inputTokens.slice(index).join(" ").toLocaleLowerCase()
+    foldSearchTerm(inputTokens.slice(index).join(" "))
   );
-  const plugins = sourcePlugins();
+  const plugins = searchScopePlugins();
   const hasDirectPluginMatch = plugins.some((plugin) =>
     matchesDirectSearch(rawQuery, pluginSearchContext(plugin))
   );
@@ -255,27 +258,38 @@ function completionMatches(value) {
     value: completionValue,
     label,
     insertValue,
+    matchValue = "",
     detail = "",
     count = 1,
   }) => {
     if (rawQuery.startsWith("@") && type !== "author") return;
-    const candidate = type === "author"
-      ? completionValue.replace(/^@/, "").toLocaleLowerCase()
-      : label.toLocaleLowerCase();
+    const candidates = type === "author"
+      ? [completionValue.replace(/^@/, "")]
+      : [label, matchValue].filter(Boolean);
     const completionQueries = type === "plugin" ? pluginQueries : [query];
-    const score = Math.min(...completionQueries.map((candidateQuery) =>
-      fuzzyScore(candidateQuery, candidate)
+    const score = Math.min(...completionQueries.flatMap((candidateQuery) =>
+      candidates.map((candidate) => fuzzyScore(candidateQuery, candidate))
     ));
     if (!Number.isFinite(score) || (score >= 100 && hasDirectPluginMatch)) return;
-    const key = `${type}:${completionValue.toLocaleLowerCase()}`;
-    const suggestion = { type, value: completionValue, label, insertValue, detail };
+    const key = `${type}:${foldSearchTerm(completionValue)}`;
+    const suggestion = {
+      type, value: completionValue, label, insertValue, matchValue, detail,
+    };
     const target = completionTarget(suggestion);
-    const targetLower = target.toLocaleLowerCase();
-    const prefix = completionQueries.some((candidateQuery) =>
-      targetLower.startsWith(candidateQuery)
-    );
-    const fullPrefix = targetLower.startsWith(String(value || "").trim().toLocaleLowerCase());
-    const targetLength = target.length;
+    const rawTargets = [target, matchValue].filter(Boolean);
+    const targets = rawTargets.map(foldSearchTerm);
+    const targetKeys = rawTargets.map(searchPhraseKey).filter(Boolean);
+    const prefix = completionQueries.some((candidateQuery) => {
+      const candidateKey = searchPhraseKey(candidateQuery);
+      return targets.some((candidate) => candidate.startsWith(candidateQuery))
+        || (candidateKey && targetKeys.some((candidate) => candidate.startsWith(candidateKey)));
+    });
+    const normalizedInput = foldSearchTerm(value);
+    const normalizedInputKey = searchPhraseKey(value);
+    const fullPrefix = targets.some((candidate) => candidate.startsWith(normalizedInput))
+      || (normalizedInputKey
+        && targetKeys.some((candidate) => candidate.startsWith(normalizedInputKey)));
+    const targetLength = Math.min(...targets.map((candidate) => candidate.length));
     const current = matches.get(key);
     if (current) {
       current.count += count;
@@ -483,6 +497,7 @@ function updateSearchSuggestions() {
   }
   searchCompletions = completionMatches(search.value);
   activeSuggestion = -1;
+  search.removeAttribute("aria-activedescendant");
   const resultCount = filteredPlugins().length;
   const summaryAction = state.terms.length ? "Add" : "Search for";
   searchSuggestions.innerHTML = `
@@ -540,12 +555,15 @@ function catalogFilterLabel(filter) {
   return filter;
 }
 
-function filteredPlugins() {
-  const result = sourcePlugins().filter((plugin) => (
+function searchScopePlugins() {
+  return sourcePlugins().filter((plugin) => (
     matchesCatalogFilter(plugin)
     && (!verificationFilters.has(state.sort) || matchesVerificationStatus(plugin, state.sort))
-    && pluginMatchesActiveSearch(plugin)
   ));
+}
+
+function filteredPlugins() {
+  const result = searchScopePlugins().filter((plugin) => pluginMatchesActiveSearch(plugin));
 
   const sorters = {
     added: (a, b) => listingTime(b) - listingTime(a) || a.name.localeCompare(b.name),

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -42,6 +42,7 @@ import {
   foldSearchTerm,
   fuzzyScore,
   handleSearchEscape,
+  hasFulltextSearchDraft,
   inlineSearchCompletionSuffix,
   matchesCommittedSearchTerm,
   matchesDirectSearch,
@@ -54,6 +55,7 @@ import {
   searchKeyAction,
   searchPhraseKey,
   searchTermDisplayValue,
+  searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
 } from "./search.js?v=20260827-01";
@@ -241,6 +243,7 @@ function pluginMatchesActiveSearch(plugin) {
 }
 
 function completionMatches(value) {
+  if (hasFulltextSearchDraft(value)) return [];
   const rawQuery = currentSearchToken(value);
   const query = foldSearchTerm(rawQuery.replace(/^@/, ""));
   if (!query) return [];
@@ -249,6 +252,13 @@ function completionMatches(value) {
     foldSearchTerm(inputTokens.slice(index).join(" "))
   );
   const plugins = searchScopePlugins();
+  const normalizedValue = normalizeSearchTerm(value);
+  const parsedDraft = parseSearchDraft(normalizedValue);
+  const fulltextTerm = parsedDraft.length
+    && parsedDraft.every((term) => term.type === "text")
+    && !/(?:^|\s)(?:tag|author|plugin):/i.test(normalizedValue)
+    ? createSearchTerm("fulltext", normalizedValue)
+    : null;
   const hasDirectPluginMatch = plugins.some((plugin) =>
     matchesDirectSearch(rawQuery, pluginSearchContext(plugin))
   );
@@ -302,6 +312,18 @@ function completionMatches(value) {
     }
   };
 
+  if (fulltextTerm) {
+    addMatch({
+      type: "fulltext",
+      value: fulltextTerm.value,
+      label: fulltextTerm.value,
+      insertValue: searchTermInputValue(fulltextTerm),
+      detail: "broad search",
+      count: plugins.filter((plugin) =>
+        matchesDirectSearch(fulltextTerm.value, pluginSearchContext(plugin))
+      ).length,
+    });
+  }
   plugins.forEach((plugin) => {
     const login = publisherLogin(plugin);
     if (login && state.source === "community") {
@@ -379,6 +401,7 @@ function setActiveSuggestion(index) {
 
 const searchTermTypeLabels = {
   text: "",
+  fulltext: "TEXT",
   tag: "TAG",
   author: "AUTHOR",
   plugin: "PLUGIN",
@@ -404,7 +427,7 @@ function updateSearchAffordances() {
   searchShortcut.hidden = active;
   search.placeholder = state.terms.length
     ? "Add search term…"
-    : "Search plugins, tags, or @authors…";
+    : "Search plugins, tag:panel, text:bar, or @author…";
 }
 
 function removeSearchTerm(index) {
@@ -509,7 +532,7 @@ function updateSearchSuggestions() {
       <button id="search-completion-${index}" class="search-suggestion" type="button" role="option"
         tabindex="-1" aria-selected="false" data-search-completion="${index}">
         <span>${escapeHtml(completion.label)}</span>
-        <small>${completion.type}${completion.detail ? ` · ${escapeHtml(completion.detail)}` : ""}${completion.count > 1 ? ` · ${completion.count}` : ""}</small>
+        <small>${completion.type === "fulltext" ? "text" : completion.type}${completion.detail ? ` · ${escapeHtml(completion.detail)}` : ""}${completion.count > 1 ? ` · ${completion.count}` : ""}</small>
       </button>`).join("")}`;
   searchSuggestions.hidden = false;
   search.setAttribute("aria-expanded", "true");

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -48,6 +48,7 @@ import {
   matchesDirectSearch,
   matchesDraftSearchTerm,
   maximumSearchTerms,
+  pluginKindKey,
   normalizeSearchTerm,
   parseSearchDraft,
   readSearchState,
@@ -227,6 +228,7 @@ function pluginMatchesActiveSearch(plugin) {
     tags: plugin.tags || [],
     pluginName: plugin.name,
     pluginId: plugin.id,
+    pluginKind: plugin.kind,
   };
   const matchesTerm = state.terms.some((term) => term.type === "text"
     ? matchesDirectSearch(term.value, matchContext)
@@ -256,7 +258,7 @@ function completionMatches(value) {
   const parsedDraft = parseSearchDraft(normalizedValue);
   const fulltextTerm = parsedDraft.length
     && parsedDraft.every((term) => term.type === "text")
-    && !/(?:^|\s)(?:tag|author|plugin):/i.test(normalizedValue)
+    && !/(?:^|\s)(?:tag|author|plugin|kind):/i.test(normalizedValue)
     ? createSearchTerm("fulltext", normalizedValue)
     : null;
   const hasDirectPluginMatch = plugins.some((plugin) =>
@@ -276,7 +278,7 @@ function completionMatches(value) {
     const candidates = type === "author"
       ? [completionValue.replace(/^@/, "")]
       : [label, matchValue].filter(Boolean);
-    const completionQueries = type === "plugin" ? pluginQueries : [query];
+    const completionQueries = ["plugin", "kind"].includes(type) ? pluginQueries : [query];
     const score = Math.min(...completionQueries.flatMap((candidateQuery) =>
       candidates.map((candidate) => fuzzyScore(candidateQuery, candidate))
     ));
@@ -312,6 +314,30 @@ function completionMatches(value) {
     }
   };
 
+  const kinds = new Map();
+  plugins.forEach((plugin) => {
+    const key = pluginKindKey(plugin.kind);
+    if (!key) return;
+    const current = kinds.get(key);
+    if (current) {
+      current.count += 1;
+      current.ambiguous ||= current.label !== plugin.kind;
+    } else {
+      kinds.set(key, { label: plugin.kind, count: 1, ambiguous: false });
+    }
+  });
+  kinds.forEach(({ label, count: kindCount, ambiguous }, key) => {
+    if (ambiguous) return;
+    addMatch({
+      type: "kind",
+      value: key,
+      label: `kind:${key}`,
+      insertValue: `kind:${key}`,
+      matchValue: label,
+      detail: label,
+      count: kindCount,
+    });
+  });
   if (fulltextTerm) {
     addMatch({
       type: "fulltext",
@@ -405,6 +431,7 @@ const searchTermTypeLabels = {
   tag: "TAG",
   author: "AUTHOR",
   plugin: "PLUGIN",
+  kind: "KIND",
 };
 
 function searchTermPresentation(term) {
@@ -413,7 +440,10 @@ function searchTermPresentation(term) {
   const plugin = normalized.type === "plugin"
     ? state.plugins.find((item) => item.id === normalized.value)
     : null;
-  const value = plugin?.name || searchTermDisplayValue(normalized);
+  const kind = normalized.type === "kind"
+    ? state.plugins.find((item) => pluginKindKey(item.kind) === normalized.value)?.kind
+    : null;
+  const value = plugin?.name || kind || searchTermDisplayValue(normalized);
   return {
     term: normalized,
     value,

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260826-01";
+} from "./shared.js?v=20260827-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260826-01";
+} from "./shared.js?v=20260827-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260826-01";
+} from "./engagement.js?v=20260827-01";
 
 function safeGitHubWebUrl(value) {
   try {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260826-01";
+} from "./shared.js?v=20260827-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -1,6 +1,6 @@
 export function fuzzyScore(query, candidate) {
-  const needle = query.toLocaleLowerCase();
-  const haystack = candidate.toLocaleLowerCase();
+  const needle = foldSearchTerm(query);
+  const haystack = foldSearchTerm(candidate);
   const contiguous = haystack.indexOf(needle);
   if (contiguous >= 0) return contiguous;
   let previous = -1;
@@ -43,7 +43,7 @@ export function selectSearchCompletions(matches, limit = 3) {
 }
 
 export function searchTokens(value) {
-  return String(value || "").trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  return foldSearchTerm(value).split(/\s+/).filter(Boolean);
 }
 
 export function currentSearchToken(value) {
@@ -61,6 +61,13 @@ export function normalizeSearchTerm(value) {
 
 export function foldSearchTerm(value) {
   return normalizeSearchTerm(value).toLowerCase();
+}
+
+export function searchPhraseKey(value) {
+  return foldSearchTerm(value)
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
 }
 
 export function createSearchTerm(type, value) {
@@ -110,7 +117,7 @@ export function uniqueSearchTerms(values) {
 }
 
 function validGitHubLogin(value) {
-  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(value);
+  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d]|$)){0,38}$/i.test(value);
 }
 
 export function parseSearchDraft(value) {
@@ -179,13 +186,17 @@ export function removeSearchTermTypeFromDraft(value, type) {
 export function matchesShortSearch(query, primaryText, searchText) {
   const normalized = foldSearchTerm(String(query || "").replace(/^@/, ""));
   if (!normalized) return true;
+  const normalizedSearchText = foldSearchTerm(searchText);
+  if (!/[\p{L}\p{M}\p{N}]/u.test(normalized)) {
+    return normalizedSearchText.includes(normalized);
+  }
   if (
     normalized.length >= 3
     && foldSearchTerm(primaryText).includes(normalized)
   ) {
     return true;
   }
-  const words = foldSearchTerm(searchText).split(/[^a-z0-9]+/).filter(Boolean);
+  const words = normalizedSearchText.match(/[\p{L}\p{M}\p{N}]+/gu) || [];
   return words.some((word) => word.startsWith(normalized));
 }
 
@@ -197,7 +208,9 @@ export function matchesDirectSearch(value, {
   const tokens = searchTokens(value);
   return tokens.length === 0 || tokens.every((token) => {
     if (token.startsWith("@")) {
-      return foldSearchTerm(publisher).startsWith(token.slice(1));
+      const requestedPublisher = token.slice(1);
+      return Boolean(requestedPublisher)
+        && foldSearchTerm(publisher).startsWith(requestedPublisher);
     }
     const normalizedText = foldSearchTerm(searchText);
     if (token.length > 3) return normalizedText.includes(token);
@@ -259,16 +272,24 @@ function completionTargetForInput(value, suggestion) {
   if (suggestion?.type !== "plugin" || pluginIndex < 0) return target;
   const pluginDraft = tokens.slice(pluginIndex).join(" ");
   const pluginTarget = `plugin:${target}`;
-  return pluginTarget.toLowerCase().startsWith(pluginDraft.toLowerCase())
+  return foldSearchTerm(pluginTarget).startsWith(foldSearchTerm(pluginDraft))
     ? pluginTarget
     : target;
 }
 
-function completionReplacementStart(value, target) {
+function completionReplacementStart(value, target, suggestion) {
   const tokens = normalizeSearchTerm(value).split(" ").filter(Boolean);
+  const rawCandidates = [target, suggestion?.matchValue].filter(Boolean);
+  const foldedCandidates = rawCandidates.map(foldSearchTerm);
+  const phraseCandidates = rawCandidates.map(searchPhraseKey).filter(Boolean);
   for (let index = 0; index < tokens.length; index += 1) {
-    const suffix = tokens.slice(index).join(" ");
-    if (target.toLowerCase().startsWith(suffix.toLowerCase())) return index;
+    const tokenSuffix = tokens.slice(index).join(" ");
+    const foldedSuffix = foldSearchTerm(tokenSuffix);
+    const phraseSuffix = searchPhraseKey(tokenSuffix);
+    if (
+      foldedCandidates.some((candidate) => candidate.startsWith(foldedSuffix))
+      || (phraseSuffix && phraseCandidates.some((candidate) => candidate.startsWith(phraseSuffix)))
+    ) return index;
   }
   return Math.max(0, tokens.length - 1);
 }
@@ -276,15 +297,16 @@ function completionReplacementStart(value, target) {
 export function applySearchCompletion(value, suggestion) {
   const target = completionTargetForInput(value, suggestion);
   const tokens = normalizeSearchTerm(value).split(" ").filter(Boolean);
-  const replacementStart = completionReplacementStart(value, target);
+  const replacementStart = completionReplacementStart(value, target, suggestion);
   return [...tokens.slice(0, replacementStart), target].join(" ");
 }
 
 export function inlineSearchCompletionSuffix(suggestion, value) {
   if (!suggestion || !value) return "";
   const completed = applySearchCompletion(value, suggestion);
-  if (!completed.toLowerCase().startsWith(value.toLowerCase())) return "";
-  return completed.length > value.length ? completed.slice(value.length) : "";
+  const normalizedValue = normalizeSearchTerm(value);
+  if (!foldSearchTerm(completed).startsWith(foldSearchTerm(normalizedValue))) return "";
+  return completed.length > normalizedValue.length ? completed.slice(normalizedValue.length) : "";
 }
 
 export function committedTermsFromDraft(value, suggestion) {
@@ -300,9 +322,9 @@ export function committedTermsFromDraft(value, suggestion) {
   const selected = createSearchTerm(suggestion.type, suggestion.value);
   if (!selected) return [];
   const target = completionTargetForInput(draft, suggestion);
-  if (target.toLowerCase().startsWith(draft.toLowerCase())) return [selected];
+  if (foldSearchTerm(target).startsWith(foldSearchTerm(draft))) return [selected];
   const tokens = draft.split(" ");
-  const replacementStart = completionReplacementStart(draft, target);
+  const replacementStart = completionReplacementStart(draft, target, suggestion);
   return [...parseSearchDraft(tokens.slice(0, replacementStart).join(" ")), selected];
 }
 

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -15,7 +15,7 @@ export function fuzzyScore(query, candidate) {
 }
 
 export function rankSearchCompletions(matches) {
-  const typeOrder = { plugin: 0, author: 1, tag: 2 };
+  const typeOrder = { plugin: 0, author: 1, tag: 2, fulltext: 3 };
   return [...matches].sort((a, b) => (
     Number(Boolean(b.fullPrefix)) - Number(Boolean(a.fullPrefix))
     || Number(Boolean(b.prefix)) - Number(Boolean(a.prefix))
@@ -31,15 +31,20 @@ export function rankSearchCompletions(matches) {
 
 export function selectSearchCompletions(matches, limit = 3) {
   const ranked = rankSearchCompletions(matches);
+  const fulltext = ranked.find((match) => match.type === "fulltext");
+  const rankedCatalogMatches = ranked.filter((match) => match !== fulltext);
   const selected = [];
   ["plugin", "author", "tag"].forEach((type) => {
-    const prefixMatch = ranked.find((match) => match.type === type && match.prefix);
+    const prefixMatch = rankedCatalogMatches.find((match) => match.type === type && match.prefix);
     if (prefixMatch) selected.push(prefixMatch);
   });
-  ranked.forEach((match) => {
+  rankedCatalogMatches.forEach((match) => {
     if (selected.length < limit && !selected.includes(match)) selected.push(match);
   });
-  return rankSearchCompletions(selected).slice(0, limit);
+  return [
+    ...(fulltext ? [fulltext] : []),
+    ...rankSearchCompletions(selected).slice(0, limit),
+  ];
 }
 
 export function searchTokens(value) {
@@ -50,8 +55,15 @@ export function currentSearchToken(value) {
   return String(value || "").match(/(?:^|\s)(\S*)$/)?.[1] || "";
 }
 
-const searchTermTypeList = ["text", "tag", "author", "plugin"];
+const searchTermTypeList = ["text", "fulltext", "tag", "author", "plugin"];
 const searchTermTypes = new Set(searchTermTypeList);
+const searchStateTermTypes = new Map([
+  ["q", "text"],
+  ["text", "fulltext"],
+  ["tag", "tag"],
+  ["author", "author"],
+  ["plugin", "plugin"],
+]);
 export const maximumSearchTerms = 24;
 export const maximumSearchTermLength = 160;
 
@@ -73,11 +85,12 @@ export function searchPhraseKey(value) {
 export function createSearchTerm(type, value) {
   const normalizedType = searchTermTypes.has(type) ? type : "text";
   let normalizedValue = normalizeSearchTerm(value);
+  if (!normalizedValue || normalizedValue.length > maximumSearchTermLength) return null;
   if (normalizedType === "author") {
     normalizedValue = normalizedValue.replace(/^@/, "");
     if (!validGitHubLogin(normalizedValue)) return null;
   }
-  if (!normalizedValue || normalizedValue.length > maximumSearchTermLength) return null;
+  if (normalizedType === "fulltext" && normalizedValue.includes("\"")) return null;
   return { type: normalizedType, value: normalizedValue };
 }
 
@@ -96,6 +109,11 @@ export function searchTermInputValue(term) {
   const normalized = createSearchTerm(term?.type, term?.value);
   if (!normalized) return "";
   if (normalized.type === "text") return normalized.value;
+  if (normalized.type === "fulltext") {
+    return normalized.value.includes(" ")
+      ? `text:"${normalized.value}"`
+      : `text:${normalized.value}`;
+  }
   if (normalized.type === "author") return `@${normalized.value}`;
   return `${normalized.type}:${normalized.value}`;
 }
@@ -120,30 +138,63 @@ function validGitHubLogin(value) {
   return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d]|$)){0,38}$/i.test(value);
 }
 
+export function hasFulltextSearchDraft(value) {
+  return /(?:^|\s)text:/i.test(normalizeSearchTerm(value));
+}
+
 export function parseSearchDraft(value) {
   const draft = normalizeSearchTerm(value);
   if (!draft) return [];
-  const pluginExpression = draft.match(/^plugin:(.+)$/i);
-  if (pluginExpression) {
-    const plugin = createSearchTerm("plugin", pluginExpression[1]);
-    return plugin ? [plugin] : [createSearchTerm("text", draft)].filter(Boolean);
-  }
-  return draft.split(" ").map((token) => {
-    const typed = token.match(/^(tag|author):(.+)$/i);
+  const parts = [...draft.matchAll(/(?:^|\s)(?:text:"([^"]*)"(?=$|\s)|(\S+))/gi)]
+    .map((match) => match[1] !== undefined
+      ? { type: "fulltext", value: match[1] }
+      : { type: "token", value: match[2] });
+  const isTypedBoundary = (part) => part.type === "fulltext"
+    || /^(?:tag|author|text|plugin):/i.test(part.value)
+    || (part.value.startsWith("@") && validGitHubLogin(part.value.slice(1)));
+  const terms = [];
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (part.type === "fulltext") {
+      const fulltext = createSearchTerm("fulltext", part.value);
+      if (fulltext) terms.push(fulltext);
+      continue;
+    }
+    const token = part.value;
+    const pluginExpression = token.match(/^plugin:(.*)$/i);
+    if (pluginExpression) {
+      const pluginValue = [pluginExpression[1]];
+      while (parts[index + 1] && !isTypedBoundary(parts[index + 1])) {
+        pluginValue.push(parts[index + 1].value);
+        index += 1;
+      }
+      const plugin = createSearchTerm("plugin", pluginValue.join(" "));
+      terms.push(plugin || createSearchTerm("text", token));
+      continue;
+    }
+    if (/^text:$/i.test(token)) continue;
+    const typed = token.match(/^(tag|author|text):(.+)$/i);
     if (typed) {
-      return createSearchTerm(typed[1].toLowerCase(), typed[2])
-        || createSearchTerm("text", token);
+      if (typed[1].toLowerCase() === "text" && typed[2].includes("\"")) {
+        terms.push(createSearchTerm("text", token));
+        continue;
+      }
+      const type = typed[1].toLowerCase() === "text" ? "fulltext" : typed[1].toLowerCase();
+      terms.push(createSearchTerm(type, typed[2]) || createSearchTerm("text", token));
+      continue;
     }
     if (token.startsWith("@") && validGitHubLogin(token.slice(1))) {
-      return createSearchTerm("author", token);
+      terms.push(createSearchTerm("author", token));
+      continue;
     }
-    return createSearchTerm("text", token);
-  }).filter(Boolean);
+    terms.push(createSearchTerm("text", token));
+  }
+  return terms.filter(Boolean);
 }
 
 export function appendSearchState(params, { terms, draft }) {
   uniqueSearchTerms(terms).forEach((term) => {
-    const key = term.type === "text" ? "q" : term.type;
+    const key = term.type === "text" ? "q" : term.type === "fulltext" ? "text" : term.type;
     params.append(key, term.value);
   });
   const normalizedDraft = normalizeSearchTerm(draft);
@@ -163,8 +214,8 @@ export function readSearchState(params) {
       if (!draft && candidate.length <= maximumSearchTermLength) draft = candidate;
       continue;
     }
-    const type = key === "q" ? "text" : key;
-    if (!searchTermTypeList.includes(type) || terms.length >= maximumSearchTerms) continue;
+    const type = searchStateTermTypes.get(key);
+    if (!type || terms.length >= maximumSearchTerms) continue;
     const term = key === "q" && value.startsWith("@") && validGitHubLogin(value.slice(1))
       ? createSearchTerm("author", value)
       : createSearchTerm(type, value);
@@ -229,6 +280,9 @@ export function matchesCommittedSearchTerm(term, {
   const normalized = createSearchTerm(term?.type, term?.value);
   if (!normalized) return false;
   const requested = foldSearchTerm(normalized.value);
+  if (normalized.type === "fulltext") {
+    return matchesDirectSearch(normalized.value, { publisher, primaryText, searchText });
+  }
   if (normalized.type === "author") return foldSearchTerm(publisher) === requested;
   if (normalized.type === "tag") {
     return tags.some((tag) => foldSearchTerm(tag) === requested);
@@ -244,6 +298,8 @@ export function matchesCommittedSearchTerm(term, {
 
 export function matchesDraftSearchTerm(term, {
   publisher,
+  primaryText,
+  searchText,
   tags = [],
   pluginName,
   pluginId,
@@ -251,6 +307,9 @@ export function matchesDraftSearchTerm(term, {
   const normalized = createSearchTerm(term?.type, term?.value);
   if (!normalized || normalized.type === "text") return false;
   const requested = foldSearchTerm(normalized.value);
+  if (normalized.type === "fulltext") {
+    return matchesDirectSearch(normalized.value, { publisher, primaryText, searchText });
+  }
   if (normalized.type === "author") return foldSearchTerm(publisher).startsWith(requested);
   if (normalized.type === "tag") {
     return tags.some((tag) => foldSearchTerm(tag).startsWith(requested));
@@ -295,7 +354,9 @@ function completionReplacementStart(value, target, suggestion) {
 }
 
 export function applySearchCompletion(value, suggestion) {
+  if (hasFulltextSearchDraft(value)) return normalizeSearchTerm(value);
   const target = completionTargetForInput(value, suggestion);
+  if (suggestion?.type === "fulltext") return target;
   const tokens = normalizeSearchTerm(value).split(" ").filter(Boolean);
   const replacementStart = completionReplacementStart(value, target, suggestion);
   return [...tokens.slice(0, replacementStart), target].join(" ");
@@ -312,15 +373,17 @@ export function inlineSearchCompletionSuffix(suggestion, value) {
 export function committedTermsFromDraft(value, suggestion) {
   const draft = normalizeSearchTerm(value);
   if (!draft) return [];
+  const parsed = parseSearchDraft(draft);
   if (!suggestion) {
-    const parsed = parseSearchDraft(draft);
     const allText = parsed.every((term) => term.type === "text");
     return parsed.length === 1 || !allText
       ? parsed
       : [createSearchTerm("text", draft)].filter(Boolean);
   }
+  if (hasFulltextSearchDraft(draft)) return parsed;
   const selected = createSearchTerm(suggestion.type, suggestion.value);
   if (!selected) return [];
+  if (selected.type === "fulltext") return [selected];
   const target = completionTargetForInput(draft, suggestion);
   if (foldSearchTerm(target).startsWith(foldSearchTerm(draft))) return [selected];
   const tokens = draft.split(" ");

--- a/site/assets/js/search.js
+++ b/site/assets/js/search.js
@@ -15,14 +15,14 @@ export function fuzzyScore(query, candidate) {
 }
 
 export function rankSearchCompletions(matches) {
-  const typeOrder = { plugin: 0, author: 1, tag: 2, fulltext: 3 };
+  const typeOrder = { plugin: 0, kind: 1, author: 2, tag: 3, fulltext: 4 };
   return [...matches].sort((a, b) => (
     Number(Boolean(b.fullPrefix)) - Number(Boolean(a.fullPrefix))
     || Number(Boolean(b.prefix)) - Number(Boolean(a.prefix))
     || (a.prefix && b.prefix
       ? (a.targetLength ?? a.label.length) - (b.targetLength ?? b.label.length)
       : 0)
-    || typeOrder[a.type] - typeOrder[b.type]
+    || (typeOrder[a.type] ?? 99) - (typeOrder[b.type] ?? 99)
     || a.score - b.score
     || b.count - a.count
     || a.label.localeCompare(b.label)
@@ -32,7 +32,10 @@ export function rankSearchCompletions(matches) {
 export function selectSearchCompletions(matches, limit = 3) {
   const ranked = rankSearchCompletions(matches);
   const fulltext = ranked.find((match) => match.type === "fulltext");
-  const rankedCatalogMatches = ranked.filter((match) => match !== fulltext);
+  const kindMatches = ranked.filter((match) => match.type === "kind").slice(0, 2);
+  const rankedCatalogMatches = ranked.filter((match) => (
+    match !== fulltext && match.type !== "kind"
+  ));
   const selected = [];
   ["plugin", "author", "tag"].forEach((type) => {
     const prefixMatch = rankedCatalogMatches.find((match) => match.type === type && match.prefix);
@@ -42,6 +45,7 @@ export function selectSearchCompletions(matches, limit = 3) {
     if (selected.length < limit && !selected.includes(match)) selected.push(match);
   });
   return [
+    ...kindMatches,
     ...(fulltext ? [fulltext] : []),
     ...rankSearchCompletions(selected).slice(0, limit),
   ];
@@ -55,7 +59,7 @@ export function currentSearchToken(value) {
   return String(value || "").match(/(?:^|\s)(\S*)$/)?.[1] || "";
 }
 
-const searchTermTypeList = ["text", "fulltext", "tag", "author", "plugin"];
+const searchTermTypeList = ["text", "fulltext", "tag", "author", "plugin", "kind"];
 const searchTermTypes = new Set(searchTermTypeList);
 const searchStateTermTypes = new Map([
   ["q", "text"],
@@ -63,6 +67,7 @@ const searchStateTermTypes = new Map([
   ["tag", "tag"],
   ["author", "author"],
   ["plugin", "plugin"],
+  ["kind", "kind"],
 ]);
 export const maximumSearchTerms = 24;
 export const maximumSearchTermLength = 160;
@@ -82,6 +87,10 @@ export function searchPhraseKey(value) {
     .replace(/\s+/g, " ");
 }
 
+export function pluginKindKey(value) {
+  return searchPhraseKey(value).replace(/ /g, "-");
+}
+
 export function createSearchTerm(type, value) {
   const normalizedType = searchTermTypes.has(type) ? type : "text";
   let normalizedValue = normalizeSearchTerm(value);
@@ -90,7 +99,9 @@ export function createSearchTerm(type, value) {
     normalizedValue = normalizedValue.replace(/^@/, "");
     if (!validGitHubLogin(normalizedValue)) return null;
   }
+  if (normalizedType === "kind") normalizedValue = pluginKindKey(normalizedValue);
   if (normalizedType === "fulltext" && normalizedValue.includes("\"")) return null;
+  if (!normalizedValue) return null;
   return { type: normalizedType, value: normalizedValue };
 }
 
@@ -150,7 +161,7 @@ export function parseSearchDraft(value) {
       ? { type: "fulltext", value: match[1] }
       : { type: "token", value: match[2] });
   const isTypedBoundary = (part) => part.type === "fulltext"
-    || /^(?:tag|author|text|plugin):/i.test(part.value)
+    || /^(?:tag|author|text|plugin|kind):/i.test(part.value)
     || (part.value.startsWith("@") && validGitHubLogin(part.value.slice(1)));
   const terms = [];
   for (let index = 0; index < parts.length; index += 1) {
@@ -173,7 +184,7 @@ export function parseSearchDraft(value) {
       continue;
     }
     if (/^text:$/i.test(token)) continue;
-    const typed = token.match(/^(tag|author|text):(.+)$/i);
+    const typed = token.match(/^(tag|author|text|kind):(.+)$/i);
     if (typed) {
       if (typed[1].toLowerCase() === "text" && typed[2].includes("\"")) {
         terms.push(createSearchTerm("text", token));
@@ -276,6 +287,7 @@ export function matchesCommittedSearchTerm(term, {
   tags = [],
   pluginName,
   pluginId,
+  pluginKind,
 }) {
   const normalized = createSearchTerm(term?.type, term?.value);
   if (!normalized) return false;
@@ -290,6 +302,7 @@ export function matchesCommittedSearchTerm(term, {
   if (normalized.type === "plugin") {
     return foldSearchTerm(pluginName) === requested || foldSearchTerm(pluginId) === requested;
   }
+  if (normalized.type === "kind") return pluginKindKey(pluginKind) === requested;
   if (requested.length > 3 || requested.includes(" ")) {
     return foldSearchTerm(searchText).includes(requested);
   }
@@ -303,6 +316,7 @@ export function matchesDraftSearchTerm(term, {
   tags = [],
   pluginName,
   pluginId,
+  pluginKind,
 }) {
   const normalized = createSearchTerm(term?.type, term?.value);
   if (!normalized || normalized.type === "text") return false;
@@ -314,6 +328,7 @@ export function matchesDraftSearchTerm(term, {
   if (normalized.type === "tag") {
     return tags.some((tag) => foldSearchTerm(tag).startsWith(requested));
   }
+  if (normalized.type === "kind") return pluginKindKey(pluginKind) === requested;
   return foldSearchTerm(pluginName).startsWith(requested)
     || foldSearchTerm(pluginId).startsWith(requested);
 }

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260826-01"></script>
+    <script type="module" src="assets/js/develop.js?v=20260827-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260826-01"></script>
+    <script type="module" src="assets/js/app.js?v=20260827-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -84,8 +84,8 @@
             <div class="search-token-editor">
               <div id="search-terms" class="search-terms" aria-label="Active search terms"></div>
               <div class="search-input-wrap">
-                <label class="sr-only" for="search-input">Search plugins</label>
-                <input id="search-input" name="plugin-search" type="search" role="combobox" placeholder="Search plugins, tags, or @authors…" maxlength="160" autocomplete="off" spellcheck="false" aria-autocomplete="both" aria-controls="search-suggestions" aria-expanded="false">
+                <label class="sr-only" for="search-input">Search plugins, tags, text, or authors</label>
+                <input id="search-input" name="plugin-search" type="search" role="combobox" placeholder="Search plugins, tag:panel, text:bar, or @author…" maxlength="160" autocomplete="off" spellcheck="false" aria-autocomplete="both" aria-controls="search-suggestions" aria-expanded="false">
                 <span id="search-fish-preview" class="search-fish-preview" aria-hidden="true" hidden><span></span><b></b></span>
               </div>
             </div>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -37,6 +37,6 @@
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260826-01"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260827-01"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260826-01"></script>
+    <script type="module" src="assets/js/publish.js?v=20260827-01"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -71,6 +71,7 @@ import {
   matchesShortSearch,
   maximumSearchTermLength,
   parseSearchDraft,
+  pluginKindKey,
   rankSearchCompletions,
   readSearchState,
   removeSearchTermTypeFromDraft,
@@ -262,19 +263,36 @@ test("completion selection preserves genuine prefixes across result types", () =
   assert.ok(selected.some(({ type, value }) => type === "tag" && value === "hyprland"));
 });
 
-test("full-text completion remains available above catalog suggestions", () => {
+test("kind and full-text completions remain available beside catalog suggestions", () => {
   const selected = selectSearchCompletions([
     { type: "plugin", value: "bar-plugin", label: "Bar Plugin", count: 1, score: 0, prefix: true },
     { type: "author", value: "bar-author", label: "@bar-author", count: 1, score: 0, prefix: true },
     { type: "tag", value: "bar", label: "bar", count: 4, score: 0, prefix: true },
     {
-      type: "fulltext", value: "bar", label: "bar", insertValue: "text:bar",
-      count: 12, score: 0, prefix: false,
+      type: "kind", value: "bar", label: "kind:bar", count: 8, score: 0,
+      prefix: true, fullPrefix: true, targetLength: 3,
+    },
+    {
+      type: "kind", value: "bar-widget", label: "kind:bar-widget", count: 1351, score: 0,
+      prefix: true, fullPrefix: true, targetLength: 10,
+    },
+    {
+      type: "fulltext",
+      value: "bar",
+      label: "bar",
+      insertValue: "text:bar",
+      count: 12,
+      score: 0,
+      prefix: false,
     },
   ]);
-  assert.equal(selected.length, 4);
-  assert.equal(selected[0].type, "fulltext");
-  assert.deepEqual(selected.slice(1).map(({ type }) => type).sort(), ["author", "plugin", "tag"]);
+  assert.equal(selected.length, 6);
+  assert.deepEqual(selected.slice(0, 2).map(({ value }) => value), ["bar", "bar-widget"]);
+  assert.equal(selected[2].type, "fulltext");
+  assert.deepEqual(
+    selected.slice(3).map(({ type }) => type).sort(),
+    ["author", "plugin", "tag"],
+  );
 });
 
 test("search tokens support multi-word matching and current-token completion", () => {
@@ -421,21 +439,73 @@ test("typed committed chips use exact field-specific matching", () => {
   assert.equal(matchesDraftSearchTerm(createSearchTerm("plugin", "Power P"), plugin), true);
 });
 
-test("explicit full-text terms preserve broad matching", () => {
-  const plugin = {
-    pluginKind: "Overlay",
+test("plain text stays broad while explicit plugin kinds match exactly", () => {
+  const floatingBar = {
+    pluginKind: "Bar",
+    primaryText: "Floating Bar charlieras262.floating-bar bar hyprland quickshell",
+    searchText: "Floating Bar full bar replacement appearance Bar bar hyprland quickshell",
+  };
+  const bongoCat = {
+    pluginKind: "Bar widget",
+    primaryText: "Bongo Cat io.github.chip-davis.omabongo bar",
+    searchText: "Bongo Cat animated mascot Bar widget bar",
+  };
+  const combinedKindDescription = {
+    pluginKind: "Service + Bar widget",
     primaryText: "Combined controls example.combined",
     searchText: "Combined service + bar widget controls and panel integration",
   };
-  assert.equal(matchesCommittedSearchTerm(createSearchTerm("fulltext", "panel"), plugin), true);
-  assert.equal(matchesDraftSearchTerm(createSearchTerm("fulltext", "panel"), plugin), true);
+  assert.equal(matchesDirectSearch("bar", floatingBar), true);
+  assert.equal(matchesDirectSearch("bar", bongoCat), true);
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("kind", "bar"), floatingBar), true);
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("kind", "bar"), bongoCat), false);
+  assert.equal(matchesCommittedSearchTerm(
+    createSearchTerm("kind", "bar-widget"),
+    bongoCat,
+  ), true);
+  assert.equal(matchesCommittedSearchTerm(
+    createSearchTerm("kind", "service-bar-widget"),
+    combinedKindDescription,
+  ), true);
+  assert.equal(matchesDraftSearchTerm(createSearchTerm("kind", "bar"), floatingBar), true);
+  assert.equal(matchesDraftSearchTerm(createSearchTerm("kind", "bar"), bongoCat), false);
+  assert.equal(matchesCommittedSearchTerm(
+    createSearchTerm("fulltext", "panel"),
+    combinedKindDescription,
+  ), true);
+  assert.equal(matchesDraftSearchTerm(
+    createSearchTerm("fulltext", "panel"),
+    combinedKindDescription,
+  ), true);
+  assert.equal(pluginKindKey("Menu + Bar widget"), "menu-bar-widget");
+  assert.equal(pluginKindKey("  BAR widget  "), "bar-widget");
+});
+
+test("catalog plugin kinds have unique stable query keys", async () => {
+  const catalog = JSON.parse(
+    await readFile(new URL("../site/catalog.json", import.meta.url), "utf8"),
+  );
+  const kindsByKey = new Map();
+  for (const plugin of catalog.plugins) {
+    const key = pluginKindKey(plugin.kind);
+    assert.ok(key, `missing kind key for ${plugin.id}`);
+    const existing = kindsByKey.get(key);
+    assert.ok(!existing || existing === plugin.kind, `${existing} collides with ${plugin.kind}`);
+    kindsByKey.set(key, plugin.kind);
+    assert.equal(matchesCommittedSearchTerm(
+      createSearchTerm("kind", key),
+      { pluginKind: plugin.kind },
+    ), true, plugin.id);
+  }
+  assert.equal(kindsByKey.size, new Set(catalog.plugins.map((plugin) => plugin.kind)).size);
 });
 
 test("typed terms normalize, parse, and deduplicate by type and value", () => {
-  assert.deepEqual(parseSearchDraft("vpn tag:bar author:@spaceXrace text:panel"), [
+  assert.deepEqual(parseSearchDraft("vpn tag:bar author:@spaceXrace kind:bar-widget text:panel"), [
     { type: "text", value: "vpn" },
     { type: "tag", value: "bar" },
     { type: "author", value: "spaceXrace" },
+    { type: "kind", value: "bar-widget" },
     { type: "fulltext", value: "panel" },
   ]);
   assert.deepEqual(parseSearchDraft("plugin:Power Profiles"), [
@@ -452,6 +522,14 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
   assert.deepEqual(parseSearchDraft("plugin:Power Profiles tag:bar"), [
     { type: "plugin", value: "Power Profiles" },
     { type: "tag", value: "bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft("plugin:Power Profiles kind:bar"), [
+    { type: "plugin", value: "Power Profiles" },
+    { type: "kind", value: "bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft("kind:bar plugin:Power Profiles"), [
+    { type: "kind", value: "bar" },
+    { type: "plugin", value: "Power Profiles" },
   ]);
   assert.deepEqual(parseSearchDraft('text:"Floating Bar"'), [
     { type: "fulltext", value: "Floating Bar" },
@@ -470,6 +548,13 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
     { type: "text", value: "Bar" },
   ]);
   assert.equal(createSearchTerm("fulltext", 'invalid"quote'), null);
+  assert.deepEqual(createSearchTerm("kind", "Service + Bar widget"), {
+    type: "kind",
+    value: "service-bar-widget",
+  });
+  assert.equal(createSearchTerm("kind", "---"), null);
+  assert.equal(createSearchTerm("kind", "x".repeat(maximumSearchTermLength + 1)), null);
+  assert.equal(pluginKindKey("Bär + Panel"), "bär-panel");
   assert.equal(hasFulltextSearchDraft("vpn text:panel"), true);
   assert.equal(hasFulltextSearchDraft("vpn panel"), false);
   assert.deepEqual(parseSearchDraft("tag: author: @bad_login @foo- @foo--bar"), [
@@ -503,10 +588,13 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
     { type: "fulltext", value: "bar" },
     { type: "tag", value: "bar" },
     { type: "tag", value: "BAR" },
+    { type: "kind", value: "Bar widget" },
+    { type: "kind", value: "bar-widget" },
   ]), [
     { type: "text", value: "bar" },
     { type: "fulltext", value: "bar" },
     { type: "tag", value: "bar" },
+    { type: "kind", value: "bar-widget" },
   ]);
   assert.notEqual(
     searchTermKey({ type: "text", value: "bar" }),
@@ -516,6 +604,10 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
     searchTermKey({ type: "text", value: "bar" }),
     searchTermKey({ type: "fulltext", value: "bar" }),
   );
+  assert.notEqual(
+    searchTermKey({ type: "text", value: "bar" }),
+    searchTermKey({ type: "kind", value: "bar" }),
+  );
 });
 
 test("chip URL state preserves ordered typed terms and the live draft", () => {
@@ -524,20 +616,22 @@ test("chip URL state preserves ordered typed terms and the live draft", () => {
     { type: "tag", value: "bar" },
     { type: "author", value: "spaceXrace" },
     { type: "plugin", value: "jkoestinger.vpn" },
+    { type: "kind", value: "bar-widget" },
     { type: "fulltext", value: "panel" },
     { type: "text", value: "bar" },
   ];
   const params = appendSearchState(new URLSearchParams(), { terms, draft: "@JJD" });
-  assert.equal(params.toString(), "q=VPN&tag=bar&author=spaceXrace&plugin=jkoestinger.vpn&text=panel&q=bar&draft=%40JJD");
+  assert.equal(params.toString(), "q=VPN&tag=bar&author=spaceXrace&plugin=jkoestinger.vpn&kind=bar-widget&text=panel&q=bar&draft=%40JJD");
   assert.deepEqual(readSearchState(params), { terms, draft: "@JJD" });
   assert.deepEqual(readSearchState(new URLSearchParams(
-    "q=VPN&q=vpn&q=%40spaceXrace&q=tag%3Abar&tag=bar&unknown=x&fulltext=panel&draft=one&draft=two"
+    "q=VPN&q=vpn&q=%40spaceXrace&q=tag%3Abar&tag=bar&kind=Bar+widget&unknown=x&fulltext=panel&draft=one&draft=two"
   )), {
     terms: [
       { type: "text", value: "VPN" },
       { type: "author", value: "spaceXrace" },
       { type: "text", value: "tag:bar" },
       { type: "tag", value: "bar" },
+      { type: "kind", value: "bar-widget" },
     ],
     draft: "one",
   });
@@ -548,6 +642,7 @@ test("chip URL state preserves ordered typed terms and the live draft", () => {
   });
   assert.equal(oversizedParams.has("draft"), false);
   assert.equal(readSearchState(new URLSearchParams(`draft=${oversizedDraft}`)).draft, "");
+  assert.deepEqual(readSearchState(new URLSearchParams(`kind=${oversizedDraft}`)).terms, []);
 
   const legacyAuthorParams = appendSearchState(new URLSearchParams(), {
     terms: [{ type: "author", value: "Confined-" }],
@@ -624,18 +719,6 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
     label: "OpenCode Usage",
     insertValue: "OpenCode Usage",
   };
-  const systemNetwork = {
-    type: "plugin",
-    value: "example.system-network",
-    label: "System & Network",
-    insertValue: "System & Network",
-  };
-  const exposePlugin = {
-    type: "plugin",
-    value: "example.expose",
-    label: "Exposé Plugin",
-    insertValue: "Exposé Plugin",
-  };
   const fulltextBar = {
     type: "fulltext",
     value: "bar",
@@ -647,6 +730,46 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
     value: "Floating Bar",
     label: "Floating Bar",
     insertValue: 'text:"Floating Bar"',
+  };
+  const kindBar = {
+    type: "kind",
+    value: "bar",
+    label: "kind:bar",
+    insertValue: "kind:bar",
+    matchValue: "Bar",
+  };
+  const kindBarWidget = {
+    type: "kind",
+    value: "bar-widget",
+    label: "kind:bar-widget",
+    insertValue: "kind:bar-widget",
+    matchValue: "Bar widget",
+  };
+  const kindServiceBarWidget = {
+    type: "kind",
+    value: "service-bar-widget",
+    label: "kind:service-bar-widget",
+    insertValue: "kind:service-bar-widget",
+    matchValue: "Service + Bar widget",
+  };
+  const kindMenuBarWidget = {
+    type: "kind",
+    value: "menu-bar-widget",
+    label: "kind:menu-bar-widget",
+    insertValue: "kind:menu-bar-widget",
+    matchValue: "Menu + Bar widget",
+  };
+  const systemNetwork = {
+    type: "plugin",
+    value: "example.system-network",
+    label: "System & Network",
+    insertValue: "System & Network",
+  };
+  const exposePlugin = {
+    type: "plugin",
+    value: "example.expose",
+    label: "Exposé Plugin",
+    insertValue: "Exposé Plugin",
   };
   assert.equal(applySearchCompletion("airvpn sys", system), "airvpn system");
   assert.equal(inlineSearchCompletionSuffix(system, "airvpn sys"), "tem");
@@ -685,15 +808,6 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
     { type: "text", value: "vpn" },
     { type: "plugin", value: "dizziee.opencode-model-usage" },
   ]);
-  assert.equal(applySearchCompletion("System Network", systemNetwork), "System & Network");
-  assert.deepEqual(committedTermsFromDraft("System Network", systemNetwork), [
-    { type: "plugin", value: "example.system-network" },
-  ]);
-  assert.equal(applySearchCompletion("Expose\u0301 P", exposePlugin), "Exposé Plugin");
-  assert.equal(inlineSearchCompletionSuffix(exposePlugin, "Expose\u0301 P"), "lugin");
-  assert.deepEqual(committedTermsFromDraft("Expose\u0301 P", exposePlugin), [
-    { type: "plugin", value: "example.expose" },
-  ]);
   assert.deepEqual(committedTermsFromDraft("dark mode"), [
     { type: "text", value: "dark mode" },
   ]);
@@ -702,6 +816,63 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
   ]);
   assert.deepEqual(committedTermsFromDraft("plugin:Power Profiles"), [
     { type: "plugin", value: "Power Profiles" },
+  ]);
+  assert.equal(applySearchCompletion("bar", kindBar), "kind:bar");
+  assert.equal(applySearchCompletion("bar wid", kindBarWidget), "kind:bar-widget");
+  assert.equal(applySearchCompletion("vpn bar", kindBar), "vpn kind:bar");
+  assert.equal(
+    inlineSearchCompletionSuffix(kindBarWidget, "kind:bar-w"),
+    "idget",
+  );
+  assert.deepEqual(committedTermsFromDraft("bar", kindBar), [
+    { type: "kind", value: "bar" },
+  ]);
+  assert.deepEqual(committedTermsFromDraft("bar wid", kindBarWidget), [
+    { type: "kind", value: "bar-widget" },
+  ]);
+  assert.deepEqual(committedTermsFromDraft("vpn bar", kindBar), [
+    { type: "text", value: "vpn" },
+    { type: "kind", value: "bar" },
+  ]);
+  assert.equal(
+    applySearchCompletion("Service Bar widget", kindServiceBarWidget),
+    "kind:service-bar-widget",
+  );
+  assert.deepEqual(
+    committedTermsFromDraft("Service Bar widget", kindServiceBarWidget),
+    [{ type: "kind", value: "service-bar-widget" }],
+  );
+  assert.deepEqual(
+    committedTermsFromDraft("vpn Service Bar widget", kindServiceBarWidget),
+    [
+      { type: "text", value: "vpn" },
+      { type: "kind", value: "service-bar-widget" },
+    ],
+  );
+  assert.deepEqual(
+    committedTermsFromDraft("Menu Bar widget", kindMenuBarWidget),
+    [{ type: "kind", value: "menu-bar-widget" }],
+  );
+  assert.equal(
+    applySearchCompletion("System Network", systemNetwork),
+    "System & Network",
+  );
+  assert.deepEqual(committedTermsFromDraft("System Network", systemNetwork), [
+    { type: "plugin", value: "example.system-network" },
+  ]);
+  assert.equal(
+    applySearchCompletion("Expose\u0301 P", exposePlugin),
+    "Exposé Plugin",
+  );
+  assert.equal(
+    inlineSearchCompletionSuffix(exposePlugin, "Expose\u0301 P"),
+    "lugin",
+  );
+  assert.deepEqual(committedTermsFromDraft("Expose\u0301 P", exposePlugin), [
+    { type: "plugin", value: "example.expose" },
+  ]);
+  assert.deepEqual(committedTermsFromDraft("kind:bar-widget"), [
+    { type: "kind", value: "bar-widget" },
   ]);
   assert.equal(applySearchCompletion("bar", fulltextBar), "text:bar");
   assert.equal(inlineSearchCompletionSuffix(fulltextBar, "bar"), "");
@@ -1059,6 +1230,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.doesNotMatch(files.license, /plugin code|trademarks|third-party content|Marketplace license scope/);
   assert.match(files.thirdPartyNotices, /Lucide[\s\S]*ISC License[\s\S]*Copyright \(c\) 2026 Lucide Icons and Contributors[\s\S]*Permission to use, copy, modify, and\/or distribute/);
   assert.match(files.favicon, /Cable icon geometry from Lucide[\s\S]*Copyright \(c\) 2026 Lucide Icons and Contributors[\s\S]*Permission to use, copy, modify, and\/or distribute[\s\S]*THE SOFTWARE IS PROVIDED "AS IS"/);
+  assert.match(files.index, />Search plugins, tags, text, or authors<\/label>/);
   assert.match(files.index, /placeholder="Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.index, /<option value="updated">Recent activity<\/option>/);
   assert.match(files.index, /<option value="stars">Most starred<\/option>[\s\S]*<option value="views">Most viewed<\/option>[\s\S]*<option value="copies">Most copied<\/option>[\s\S]*<option value="hearts">Most hearts<\/option>/);
@@ -1282,8 +1454,6 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.develop, /omarchy plugin validate/);
   assert.match(files.develop, /qs log -p/);
   assert.doesNotMatch(files.develop, /<script[^>]+src=["']https?:/);
-  assert.match(files.index, />Search plugins, tags, text, or authors<\/label>/);
-  assert.match(files.index, /placeholder="Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.index, /<h2 id="recent-title">RECENTLY ADDED<\/h2>/);
   assert.match(files.publish, /<span>3 min read<\/span>/);
   assert.equal((files.publish.match(/class="docs-section"/g) || []).length, 3);
@@ -1311,8 +1481,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /matchesDirectSearch\(term\.value, matchContext\)/);
   assert.match(files.app, /const verificationFilters = new Set\(\["verified", "unverified"\]\)/);
   assert.match(files.app, /function searchScopePlugins\(\) \{[\s\S]*matchesCatalogFilter\(plugin\)[\s\S]*!verificationFilters\.has\(state\.sort\) \|\| matchesVerificationStatus\(plugin, state\.sort\)/);
-  assert.match(files.app, /function completionMatches\(value\) \{\s*if \(hasFulltextSearchDraft\(value\)\) return \[\]/);
-  assert.match(files.app, /function completionMatches\(value\) \{[\s\S]*const plugins = searchScopePlugins\(\)/);
+  assert.match(files.app, /function completionMatches\(value\) \{[\s\S]*const query = foldSearchTerm\([\s\S]*const plugins = searchScopePlugins\(\)/);
+  assert.match(files.app, /type: "kind",[\s\S]*label: `kind:\$\{key\}`,[\s\S]*matchValue: label,[\s\S]*detail: label/);
   assert.match(files.app, /type: "fulltext",[\s\S]*insertValue: searchTermInputValue\(fulltextTerm\),[\s\S]*detail: "broad search"/);
   assert.match(files.app, /completion\.type === "fulltext" \? "text" : completion\.type/);
   assert.match(files.app, /"Search plugins, tag:panel, text:bar, or @author…"/);
@@ -1334,10 +1504,14 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.searchJs, /function readSearchState\(params\)/);
   assert.match(files.searchJs, /function matchesCommittedSearchTerm\(term, \{/);
   assert.match(files.searchJs, /function matchesDirectSearch\(value, \{/);
+  assert.match(files.searchJs, /function pluginKindKey\(value\)/);
+  assert.match(files.searchJs, /normalized\.type === "kind"\) return pluginKindKey\(pluginKind\) === requested/);
+  assert.doesNotMatch(files.searchJs, /exactPluginKindSearches|matchesTextSearch/);
   assert.match(files.searchJs, /function handleSearchEscape\(event,/);
   assert.match(files.searchJs, /function inlineSearchCompletionSuffix\(suggestion, value\) \{[\s\S]*const normalizedValue = normalizeSearchTerm\(value\);[\s\S]*foldSearchTerm\(completed\)/);
   assert.match(files.searchJs, /function searchPhraseKey\(value\)/);
   assert.match(files.searchJs, /function searchKeyAction\(\{/);
+  assert.match(files.app, /function completionMatches\(value\) \{\s*if \(hasFulltextSearchDraft\(value\)\) return \[\]/);
   assert.match(files.app, /function updateSearchSuggestions\(\)/);
   assert.match(files.app, /searchCompletions = completionMatches\(search\.value\);\s*activeSuggestion = -1;\s*search\.removeAttribute\("aria-activedescendant"\)/);
   assert.match(files.app, /function inlineSuggestionIndex\(\)/);
@@ -1356,7 +1530,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /if \(state\.sort !== sourceDefaultSort\(\)\) params\.set\("sort", state\.sort\)/);
   assert.match(files.app, /readSearchState\(params\)/);
   assert.match(files.app, /const requestedSort = params\.get\("sort"\) \|\| sourceDefaultSort\(\);[\s\S]*availableSortOptions\(\)\.some\(\(\[value\]\) => value === requestedSort\)/);
-  assert.match(files.app, /const searchTermTypeLabels = \{[\s\S]*fulltext: "TEXT"/);
+  assert.match(files.app, /const searchTermTypeLabels = \{[\s\S]*fulltext: "TEXT"[\s\S]*kind: "KIND"/);
   assert.match(files.app, /class="search-term-type"/);
   assert.match(files.app, /function commitSearchDraft\(completion\)/);
   assert.match(files.app, /function clearSearchTerms\(\{ focus = true \} = \{\}\)/);

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -63,6 +63,7 @@ import {
   currentSearchToken,
   fuzzyScore,
   handleSearchEscape,
+  hasFulltextSearchDraft,
   inlineSearchCompletionSuffix,
   matchesCommittedSearchTerm,
   matchesDirectSearch,
@@ -261,6 +262,21 @@ test("completion selection preserves genuine prefixes across result types", () =
   assert.ok(selected.some(({ type, value }) => type === "tag" && value === "hyprland"));
 });
 
+test("full-text completion remains available above catalog suggestions", () => {
+  const selected = selectSearchCompletions([
+    { type: "plugin", value: "bar-plugin", label: "Bar Plugin", count: 1, score: 0, prefix: true },
+    { type: "author", value: "bar-author", label: "@bar-author", count: 1, score: 0, prefix: true },
+    { type: "tag", value: "bar", label: "bar", count: 4, score: 0, prefix: true },
+    {
+      type: "fulltext", value: "bar", label: "bar", insertValue: "text:bar",
+      count: 12, score: 0, prefix: false,
+    },
+  ]);
+  assert.equal(selected.length, 4);
+  assert.equal(selected[0].type, "fulltext");
+  assert.deepEqual(selected.slice(1).map(({ type }) => type).sort(), ["author", "plugin", "tag"]);
+});
+
 test("search tokens support multi-word matching and current-token completion", () => {
   assert.deepEqual(searchTokens("  AirVPN   system "), ["airvpn", "system"]);
   assert.deepEqual(searchTokens("  Expose\u0301   System "), ["exposé", "system"]);
@@ -405,15 +421,57 @@ test("typed committed chips use exact field-specific matching", () => {
   assert.equal(matchesDraftSearchTerm(createSearchTerm("plugin", "Power P"), plugin), true);
 });
 
+test("explicit full-text terms preserve broad matching", () => {
+  const plugin = {
+    pluginKind: "Overlay",
+    primaryText: "Combined controls example.combined",
+    searchText: "Combined service + bar widget controls and panel integration",
+  };
+  assert.equal(matchesCommittedSearchTerm(createSearchTerm("fulltext", "panel"), plugin), true);
+  assert.equal(matchesDraftSearchTerm(createSearchTerm("fulltext", "panel"), plugin), true);
+});
+
 test("typed terms normalize, parse, and deduplicate by type and value", () => {
-  assert.deepEqual(parseSearchDraft("vpn tag:bar author:@spaceXrace"), [
+  assert.deepEqual(parseSearchDraft("vpn tag:bar author:@spaceXrace text:panel"), [
     { type: "text", value: "vpn" },
     { type: "tag", value: "bar" },
     { type: "author", value: "spaceXrace" },
+    { type: "fulltext", value: "panel" },
   ]);
   assert.deepEqual(parseSearchDraft("plugin:Power Profiles"), [
     { type: "plugin", value: "Power Profiles" },
   ]);
+  assert.deepEqual(parseSearchDraft('plugin:Power Profiles text:"Floating Bar"'), [
+    { type: "plugin", value: "Power Profiles" },
+    { type: "fulltext", value: "Floating Bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft('text:"Floating Bar" plugin:Power Profiles'), [
+    { type: "fulltext", value: "Floating Bar" },
+    { type: "plugin", value: "Power Profiles" },
+  ]);
+  assert.deepEqual(parseSearchDraft("plugin:Power Profiles tag:bar"), [
+    { type: "plugin", value: "Power Profiles" },
+    { type: "tag", value: "bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft('text:"Floating Bar"'), [
+    { type: "fulltext", value: "Floating Bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft('tag:security text:"Floating Bar"'), [
+    { type: "tag", value: "security" },
+    { type: "fulltext", value: "Floating Bar" },
+  ]);
+  assert.deepEqual(parseSearchDraft('text:"Floating Bar" tag:security'), [
+    { type: "fulltext", value: "Floating Bar" },
+    { type: "tag", value: "security" },
+  ]);
+  assert.deepEqual(parseSearchDraft("text:"), []);
+  assert.deepEqual(parseSearchDraft('text:"Floating Bar'), [
+    { type: "text", value: 'text:"Floating' },
+    { type: "text", value: "Bar" },
+  ]);
+  assert.equal(createSearchTerm("fulltext", 'invalid"quote'), null);
+  assert.equal(hasFulltextSearchDraft("vpn text:panel"), true);
+  assert.equal(hasFulltextSearchDraft("vpn panel"), false);
   assert.deepEqual(parseSearchDraft("tag: author: @bad_login @foo- @foo--bar"), [
     { type: "text", value: "tag:" },
     { type: "text", value: "author:" },
@@ -436,17 +494,27 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
     removeSearchTermTypeFromDraft("vpn tag:bar @spaceXrace", "author"),
     "vpn tag:bar",
   );
+  assert.equal(
+    removeSearchTermTypeFromDraft('text:"Floating Bar" @spaceXrace', "author"),
+    'text:"Floating Bar"',
+  );
   assert.deepEqual(uniqueSearchTerms([
     { type: "text", value: "bar" },
+    { type: "fulltext", value: "bar" },
     { type: "tag", value: "bar" },
     { type: "tag", value: "BAR" },
   ]), [
     { type: "text", value: "bar" },
+    { type: "fulltext", value: "bar" },
     { type: "tag", value: "bar" },
   ]);
   assert.notEqual(
     searchTermKey({ type: "text", value: "bar" }),
     searchTermKey({ type: "tag", value: "bar" }),
+  );
+  assert.notEqual(
+    searchTermKey({ type: "text", value: "bar" }),
+    searchTermKey({ type: "fulltext", value: "bar" }),
   );
 });
 
@@ -456,13 +524,14 @@ test("chip URL state preserves ordered typed terms and the live draft", () => {
     { type: "tag", value: "bar" },
     { type: "author", value: "spaceXrace" },
     { type: "plugin", value: "jkoestinger.vpn" },
+    { type: "fulltext", value: "panel" },
     { type: "text", value: "bar" },
   ];
   const params = appendSearchState(new URLSearchParams(), { terms, draft: "@JJD" });
-  assert.equal(params.toString(), "q=VPN&tag=bar&author=spaceXrace&plugin=jkoestinger.vpn&q=bar&draft=%40JJD");
+  assert.equal(params.toString(), "q=VPN&tag=bar&author=spaceXrace&plugin=jkoestinger.vpn&text=panel&q=bar&draft=%40JJD");
   assert.deepEqual(readSearchState(params), { terms, draft: "@JJD" });
   assert.deepEqual(readSearchState(new URLSearchParams(
-    "q=VPN&q=vpn&q=%40spaceXrace&q=tag%3Abar&tag=bar&unknown=x&draft=one&draft=two"
+    "q=VPN&q=vpn&q=%40spaceXrace&q=tag%3Abar&tag=bar&unknown=x&fulltext=panel&draft=one&draft=two"
   )), {
     terms: [
       { type: "text", value: "VPN" },
@@ -567,6 +636,18 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
     label: "Exposé Plugin",
     insertValue: "Exposé Plugin",
   };
+  const fulltextBar = {
+    type: "fulltext",
+    value: "bar",
+    label: "bar",
+    insertValue: "text:bar",
+  };
+  const fulltextFloatingBar = {
+    type: "fulltext",
+    value: "Floating Bar",
+    label: "Floating Bar",
+    insertValue: 'text:"Floating Bar"',
+  };
   assert.equal(applySearchCompletion("airvpn sys", system), "airvpn system");
   assert.equal(inlineSearchCompletionSuffix(system, "airvpn sys"), "tem");
   assert.deepEqual(committedTermsFromDraft("airvpn sys", system), [
@@ -621,6 +702,29 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
   ]);
   assert.deepEqual(committedTermsFromDraft("plugin:Power Profiles"), [
     { type: "plugin", value: "Power Profiles" },
+  ]);
+  assert.equal(applySearchCompletion("bar", fulltextBar), "text:bar");
+  assert.equal(inlineSearchCompletionSuffix(fulltextBar, "bar"), "");
+  assert.deepEqual(committedTermsFromDraft("bar", fulltextBar), [
+    { type: "fulltext", value: "bar" },
+  ]);
+  assert.equal(
+    applySearchCompletion("Floating Bar", fulltextFloatingBar),
+    'text:"Floating Bar"',
+  );
+  assert.deepEqual(committedTermsFromDraft("Floating Bar", fulltextFloatingBar), [
+    { type: "fulltext", value: "Floating Bar" },
+  ]);
+  assert.deepEqual(committedTermsFromDraft("text:panel"), [
+    { type: "fulltext", value: "panel" },
+  ]);
+  assert.deepEqual(committedTermsFromDraft('text:"Floating Bar"'), [
+    { type: "fulltext", value: "Floating Bar" },
+  ]);
+  assert.equal(applySearchCompletion("text:bar", system), "text:bar");
+  assert.equal(inlineSearchCompletionSuffix(system, "text:bar"), "");
+  assert.deepEqual(committedTermsFromDraft("text:bar", system), [
+    { type: "fulltext", value: "bar" },
   ]);
   assert.deepEqual(committedTermsFromDraft("tag:bar @spaceXrace"), [
     { type: "tag", value: "bar" },
@@ -955,7 +1059,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.doesNotMatch(files.license, /plugin code|trademarks|third-party content|Marketplace license scope/);
   assert.match(files.thirdPartyNotices, /Lucide[\s\S]*ISC License[\s\S]*Copyright \(c\) 2026 Lucide Icons and Contributors[\s\S]*Permission to use, copy, modify, and\/or distribute/);
   assert.match(files.favicon, /Cable icon geometry from Lucide[\s\S]*Copyright \(c\) 2026 Lucide Icons and Contributors[\s\S]*Permission to use, copy, modify, and\/or distribute[\s\S]*THE SOFTWARE IS PROVIDED "AS IS"/);
-  assert.match(files.index, /placeholder="Search plugins, tags, or @authors…"/);
+  assert.match(files.index, /placeholder="Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.index, /<option value="updated">Recent activity<\/option>/);
   assert.match(files.index, /<option value="stars">Most starred<\/option>[\s\S]*<option value="views">Most viewed<\/option>[\s\S]*<option value="copies">Most copied<\/option>[\s\S]*<option value="hearts">Most hearts<\/option>/);
   assert.match(files.index, /<span class="sr-only">Sort or filter plugins<\/span>[\s\S]*<select id="sort-select">[\s\S]*<option value="name">A–Z<\/option>[\s\S]*<option value="verified">Verified<\/option>[\s\S]*<option value="unverified">Unverified<\/option>/);
@@ -1178,6 +1282,8 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.develop, /omarchy plugin validate/);
   assert.match(files.develop, /qs log -p/);
   assert.doesNotMatch(files.develop, /<script[^>]+src=["']https?:/);
+  assert.match(files.index, />Search plugins, tags, text, or authors<\/label>/);
+  assert.match(files.index, /placeholder="Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.index, /<h2 id="recent-title">RECENTLY ADDED<\/h2>/);
   assert.match(files.publish, /<span>3 min read<\/span>/);
   assert.equal((files.publish.match(/class="docs-section"/g) || []).length, 3);
@@ -1205,7 +1311,11 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /matchesDirectSearch\(term\.value, matchContext\)/);
   assert.match(files.app, /const verificationFilters = new Set\(\["verified", "unverified"\]\)/);
   assert.match(files.app, /function searchScopePlugins\(\) \{[\s\S]*matchesCatalogFilter\(plugin\)[\s\S]*!verificationFilters\.has\(state\.sort\) \|\| matchesVerificationStatus\(plugin, state\.sort\)/);
+  assert.match(files.app, /function completionMatches\(value\) \{\s*if \(hasFulltextSearchDraft\(value\)\) return \[\]/);
   assert.match(files.app, /function completionMatches\(value\) \{[\s\S]*const plugins = searchScopePlugins\(\)/);
+  assert.match(files.app, /type: "fulltext",[\s\S]*insertValue: searchTermInputValue\(fulltextTerm\),[\s\S]*detail: "broad search"/);
+  assert.match(files.app, /completion\.type === "fulltext" \? "text" : completion\.type/);
+  assert.match(files.app, /"Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.app, /function filteredPlugins\(\) \{[\s\S]*searchScopePlugins\(\)\.filter\(\(plugin\) => pluginMatchesActiveSearch\(plugin\)\)/);
   assert.match(files.app, /const taxonomyFilterTags = \["ai", "games", "security"\]/);
   assert.match(files.app, /value: `tag:\$\{tag\}`/);
@@ -1218,6 +1328,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.searchJs, /function currentSearchToken\(value\)/);
   assert.match(files.searchJs, /function matchesShortSearch\(query, primaryText, searchText\)/);
   assert.match(files.searchJs, /function createSearchTerm\(type, value\)/);
+  assert.match(files.searchJs, /function hasFulltextSearchDraft\(value\)/);
   assert.match(files.searchJs, /function parseSearchDraft\(value\)/);
   assert.match(files.searchJs, /function appendSearchState\(params, \{ terms, draft \}\)/);
   assert.match(files.searchJs, /function readSearchState\(params\)/);
@@ -1245,7 +1356,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /if \(state\.sort !== sourceDefaultSort\(\)\) params\.set\("sort", state\.sort\)/);
   assert.match(files.app, /readSearchState\(params\)/);
   assert.match(files.app, /const requestedSort = params\.get\("sort"\) \|\| sourceDefaultSort\(\);[\s\S]*availableSortOptions\(\)\.some\(\(\[value\]\) => value === requestedSort\)/);
-  assert.match(files.app, /const searchTermTypeLabels = \{/);
+  assert.match(files.app, /const searchTermTypeLabels = \{[\s\S]*fulltext: "TEXT"/);
   assert.match(files.app, /class="search-term-type"/);
   assert.match(files.app, /function commitSearchDraft\(completion\)/);
   assert.match(files.app, /function clearSearchTerms\(\{ focus = true \} = \{\}\)/);

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -263,8 +263,73 @@ test("completion selection preserves genuine prefixes across result types", () =
 
 test("search tokens support multi-word matching and current-token completion", () => {
   assert.deepEqual(searchTokens("  AirVPN   system "), ["airvpn", "system"]);
+  assert.deepEqual(searchTokens("  Expose\u0301   System "), ["exposé", "system"]);
   assert.equal(currentSearchToken("airvpn sys"), "sys");
   assert.equal(currentSearchToken("airvpn "), "");
+  assert.equal(fuzzyScore("Expose\u0301", "Exposé"), 0);
+});
+
+test("direct search handles standalone punctuation in plugin names", () => {
+  const pluginNames = [
+    "Media Controls + Album Art",
+    "System & Network",
+    "1440 - Day Countdown",
+    "OmaScribe — AI Meeting Notes",
+  ];
+  for (const pluginName of pluginNames) {
+    assert.equal(matchesDirectSearch(pluginName, {
+      primaryText: pluginName,
+      searchText: pluginName,
+    }), true, pluginName);
+  }
+  assert.equal(matchesDirectSearch("&", {
+    primaryText: "System & Network",
+    searchText: "System & Network",
+  }), true);
+  assert.equal(matchesDirectSearch("&", {
+    primaryText: "System Network",
+    searchText: "System Network",
+  }), false);
+  assert.equal(matchesDirectSearch("System + Network", {
+    primaryText: "System & Network",
+    searchText: "System & Network",
+  }), false);
+  assert.equal(matchesDirectSearch("@", {
+    publisher: "jcnecio",
+    primaryText: "System & Network",
+    searchText: "System & Network jcnecio @jcnecio",
+  }), false);
+});
+
+test("short searches use Unicode-aware word prefixes", () => {
+  assert.equal(matchesDirectSearch("农历", {
+    primaryText: "Lunar Calendar io.github.tuthan.omarchy-lunar-calendar",
+    searchText: "East Asian Lunar Calendar (Lịch Âm / 农历)",
+  }), true);
+  assert.equal(matchesDirectSearch("全部", {
+    primaryText: "Zenbu io.github.weedwhitesandwine.zenbu",
+    searchText: "全部 — a theme-aware launcher for everything",
+  }), true);
+  assert.equal(matchesDirectSearch("調べ", {
+    primaryText: "Shirabe ga-research.shirabe",
+    searchText: "調べ — quick lookup overlay",
+  }), true);
+  assert.equal(matchesDirectSearch("农", {
+    primaryText: "Lunar Calendar",
+    searchText: "East Asian Lunar Calendar / 农历",
+  }), true);
+  assert.equal(matchesDirectSearch("历", {
+    primaryText: "Lunar Calendar",
+    searchText: "East Asian Lunar Calendar / 农历",
+  }), false);
+  assert.equal(matchesDirectSearch("中文插", {
+    primaryText: "Example plugin",
+    searchText: "Example description 中文插件",
+  }), true);
+  assert.equal(matchesDirectSearch("ar", {
+    primaryText: "Example bar plugin",
+    searchText: "Example bar plugin",
+  }), false);
 });
 
 test("short searches find terms within plugin names and tags", () => {
@@ -353,9 +418,20 @@ test("typed terms normalize, parse, and deduplicate by type and value", () => {
     { type: "text", value: "tag:" },
     { type: "text", value: "author:" },
     { type: "text", value: "@bad_login" },
-    { type: "text", value: "@foo-" },
+    { type: "author", value: "foo-" },
     { type: "text", value: "@foo--bar" },
   ]);
+  assert.deepEqual(createSearchTerm("author", "Confined-"), {
+    type: "author",
+    value: "Confined-",
+  });
+  assert.equal(createSearchTerm("author", "-confined"), null);
+  assert.equal(createSearchTerm("author", "confined--legacy"), null);
+  assert.deepEqual(committedTermsFromDraft("@Confin", {
+    type: "author",
+    value: "Confined-",
+    label: "@Confined-",
+  }), [{ type: "author", value: "Confined-" }]);
   assert.equal(
     removeSearchTermTypeFromDraft("vpn tag:bar @spaceXrace", "author"),
     "vpn tag:bar",
@@ -403,6 +479,16 @@ test("chip URL state preserves ordered typed terms and the live draft", () => {
   });
   assert.equal(oversizedParams.has("draft"), false);
   assert.equal(readSearchState(new URLSearchParams(`draft=${oversizedDraft}`)).draft, "");
+
+  const legacyAuthorParams = appendSearchState(new URLSearchParams(), {
+    terms: [{ type: "author", value: "Confined-" }],
+    draft: "",
+  });
+  assert.equal(legacyAuthorParams.toString(), "author=Confined-");
+  assert.deepEqual(readSearchState(legacyAuthorParams), {
+    terms: [{ type: "author", value: "Confined-" }],
+    draft: "",
+  });
 });
 
 test("catalog all-view controls and URL state cover result boundaries", () => {
@@ -469,6 +555,18 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
     label: "OpenCode Usage",
     insertValue: "OpenCode Usage",
   };
+  const systemNetwork = {
+    type: "plugin",
+    value: "example.system-network",
+    label: "System & Network",
+    insertValue: "System & Network",
+  };
+  const exposePlugin = {
+    type: "plugin",
+    value: "example.expose",
+    label: "Exposé Plugin",
+    insertValue: "Exposé Plugin",
+  };
   assert.equal(applySearchCompletion("airvpn sys", system), "airvpn system");
   assert.equal(inlineSearchCompletionSuffix(system, "airvpn sys"), "tem");
   assert.deepEqual(committedTermsFromDraft("airvpn sys", system), [
@@ -505,6 +603,15 @@ test("Fish completion creates typed current-token and stable plugin terms", () =
   assert.deepEqual(committedTermsFromDraft("vpn OpenCode U", openCodeUsage), [
     { type: "text", value: "vpn" },
     { type: "plugin", value: "dizziee.opencode-model-usage" },
+  ]);
+  assert.equal(applySearchCompletion("System Network", systemNetwork), "System & Network");
+  assert.deepEqual(committedTermsFromDraft("System Network", systemNetwork), [
+    { type: "plugin", value: "example.system-network" },
+  ]);
+  assert.equal(applySearchCompletion("Expose\u0301 P", exposePlugin), "Exposé Plugin");
+  assert.equal(inlineSearchCompletionSuffix(exposePlugin, "Expose\u0301 P"), "lugin");
+  assert.deepEqual(committedTermsFromDraft("Expose\u0301 P", exposePlugin), [
+    { type: "plugin", value: "example.expose" },
   ]);
   assert.deepEqual(committedTermsFromDraft("dark mode"), [
     { type: "text", value: "dark mode" },
@@ -786,7 +893,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260826-01");
+  assert.equal(keys[0], "20260827-01");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
@@ -1097,7 +1204,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /function pluginMatchesActiveSearch\(plugin\)/);
   assert.match(files.app, /matchesDirectSearch\(term\.value, matchContext\)/);
   assert.match(files.app, /const verificationFilters = new Set\(\["verified", "unverified"\]\)/);
-  assert.match(files.app, /function filteredPlugins\(\) \{[\s\S]*matchesCatalogFilter\(plugin\)[\s\S]*!verificationFilters\.has\(state\.sort\) \|\| matchesVerificationStatus\(plugin, state\.sort\)[\s\S]*pluginMatchesActiveSearch\(plugin\)/);
+  assert.match(files.app, /function searchScopePlugins\(\) \{[\s\S]*matchesCatalogFilter\(plugin\)[\s\S]*!verificationFilters\.has\(state\.sort\) \|\| matchesVerificationStatus\(plugin, state\.sort\)/);
+  assert.match(files.app, /function completionMatches\(value\) \{[\s\S]*const plugins = searchScopePlugins\(\)/);
+  assert.match(files.app, /function filteredPlugins\(\) \{[\s\S]*searchScopePlugins\(\)\.filter\(\(plugin\) => pluginMatchesActiveSearch\(plugin\)\)/);
   assert.match(files.app, /const taxonomyFilterTags = \["ai", "games", "security"\]/);
   assert.match(files.app, /value: `tag:\$\{tag\}`/);
   assert.match(files.app, /return labels\.length \? labels : \[category \|\| "System"\]/);
@@ -1115,9 +1224,11 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.searchJs, /function matchesCommittedSearchTerm\(term, \{/);
   assert.match(files.searchJs, /function matchesDirectSearch\(value, \{/);
   assert.match(files.searchJs, /function handleSearchEscape\(event,/);
-  assert.match(files.searchJs, /function inlineSearchCompletionSuffix\(suggestion, value\)/);
+  assert.match(files.searchJs, /function inlineSearchCompletionSuffix\(suggestion, value\) \{[\s\S]*const normalizedValue = normalizeSearchTerm\(value\);[\s\S]*foldSearchTerm\(completed\)/);
+  assert.match(files.searchJs, /function searchPhraseKey\(value\)/);
   assert.match(files.searchJs, /function searchKeyAction\(\{/);
   assert.match(files.app, /function updateSearchSuggestions\(\)/);
+  assert.match(files.app, /searchCompletions = completionMatches\(search\.value\);\s*activeSuggestion = -1;\s*search\.removeAttribute\("aria-activedescendant"\)/);
   assert.match(files.app, /function inlineSuggestionIndex\(\)/);
   assert.match(files.app, /function updateFishPreview\(\)/);
   assert.match(files.app, /class="search-query-summary"/);


### PR DESCRIPTION
## Summary

- fix punctuation, Unicode, publisher, completion-scope, and combobox ARIA edge cases in catalog search
- add explicit `text:` broad-search terms with completions, chips, and `text=` URL state
- add exact dynamic `kind:` filters derived from catalog plugin kinds, including completions, chips, and `kind=` URL state
- prioritize explicit KIND and TEXT modes before tag, plugin, and author suggestions

Plain search terms remain broad. Selecting or entering `kind:` opts into exact plugin-kind matching; ordinary words such as `bar` are not silently converted into kind filters. Search terms retain the existing OR semantics.

## Validation

- `npm test` — 223/223 passed
- JavaScript syntax checks passed for all site entry and search modules
- `git diff --check` passed
- all 1,596 current community plugin names match their own name search
- current catalog kind keys are valid and collision-free
- Chromium verified KIND → TEXT → catalog suggestion order and keyboard selection
- Chromium regression coverage included punctuation, CJK, legacy GitHub owners, URL restoration, ARIA state, Unicode/NFD completion, and responsive widths
