### PR TITLE
Show README inline on plugin detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "omarchy-plugin-marketplace",
       "version": "0.1.0",
       "devDependencies": {
+        "marked": "^18.0.11",
+        "sanitize-html": "^2.17.7",
         "sharp": "0.35.3"
       },
       "engines": {
@@ -600,6 +602,23 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -608,6 +627,240 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+      "integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+      "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/semver": {
@@ -671,6 +924,16 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "node --test"
   },
   "devDependencies": {
+    "marked": "^18.0.11",
+    "sanitize-html": "^2.17.7",
     "sharp": "0.35.3"
   }
 }

--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -11,6 +11,8 @@ import {
 } from "node:fs/promises";
 import { dirname, extname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
 import sharp from "sharp";
 import {
   catalogVerificationFields,
@@ -26,11 +28,15 @@ const registryPath = resolve(root, "registry.json");
 const catalogPath = resolve(root, "site/catalog.json");
 const previewDirectory = resolve(root, "site/assets/img/plugins");
 const previewParent = dirname(previewDirectory);
+const readmeDirectory = resolve(root, "site/assets/readme");
+const readmeParent = dirname(readmeDirectory);
 export const previewByteLimit = 50 * 1024 * 1024;
 export const previewPixelLimit = 40_000_000;
 export const previewCardLimit = 720;
 export const previewDetailLimit = 1600;
 const fileLimit = 1024 * 1024;
+export const readmeByteLimit = 256 * 1024;
+export const readmeRenderedLimit = 512 * 1024;
 const requestTimeout = 15_000;
 const accents = ["lime", "amber", "coral", "cyan", "violet", "rose"];
 const supportedKinds = new Set(["bar", "bar-widget", "menu", "overlay", "panel", "service"]);
@@ -234,7 +240,7 @@ function rawUrl(repository, commitSha, path) {
 
 async function readSnapshotBuffer(repository, path, commitSha, limit, code) {
   const response = await fetchWithTimeout(rawUrl(repository, commitSha, path), {
-    headers: { "User-Agent": "omarchy-plugin-marketplace-catalog-builder" },
+    headers: githubHeaders(),
   });
   if (!response.ok) {
     checkError(
@@ -675,6 +681,89 @@ async function stageSnapshotPreview(snapshot, stageDirectory) {
   for (const output of snapshot.outputs) {
     await writeFile(resolve(stageDirectory, output.fileName), output.buffer);
   }
+}
+
+export const readmeSanitizeOptions = Object.freeze({
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+  allowedAttributes: {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    img: ["src", "alt", "width", "height"],
+    a: ["href", "name", "target", "rel", "title"],
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+  allowedSchemesByTag: { img: ["http", "https"] },
+  transformTags: {
+    a: (_tagName, attribs) => ({
+      tagName: "a",
+      attribs: { ...attribs, target: "_blank", rel: "noreferrer" },
+    }),
+  },
+});
+
+function resolveReadmeUrl(value, baseUrl) {
+  if (!value || !baseUrl) return value;
+  if (/^(https?:|mailto:)/i.test(value)) return value;
+  if (value.startsWith("//")) return `https:${value}`;
+  if (value.startsWith("/")) {
+    const u = new URL(baseUrl);
+    return `${u.origin}${value}`;
+  }
+  return `${baseUrl}/${value}`;
+}
+
+export function renderReadmeHtml(markdown, baseUrl = "") {
+  const raw = marked.parse(String(markdown || ""), { async: false });
+  const html = sanitizeHtml(raw, {
+    ...readmeSanitizeOptions,
+    transformTags: {
+      a: (_tagName, attribs) => ({
+        tagName: "a",
+        attribs: { ...attribs, href: resolveReadmeUrl(attribs.href, baseUrl), target: "_blank", rel: "noreferrer" },
+      }),
+      img: (_tagName, attribs) => ({
+        tagName: "img",
+        attribs: { ...attribs, src: resolveReadmeUrl(attribs.src, baseUrl) },
+      }),
+    },
+  });
+  if (html.length > readmeRenderedLimit) {
+    return html.slice(0, readmeRenderedLimit);
+  }
+  return html;
+}
+
+function readmePathFor(context) {
+  const rootFiles = context.tree.filter((entry) => !entry.path.includes("/") && isBlob(entry));
+  const readme = rootFiles.find((entry) => /^readme(?:\.[^/]+)?$/i.test(entry.path));
+  return readme?.path || null;
+}
+
+async function loadSnapshotReadme(source, context) {
+  if (source.type === "builtin" || context.repositoryLayout === "suite") return null;
+  const path = readmePathFor(context);
+  if (!path) return null;
+  const entry = treeEntry(context, path);
+  if (!isBlob(entry) || !Number.isFinite(entry.size) || entry.size < 1 || entry.size > readmeByteLimit) {
+    return null;
+  }
+  const buffer = await readSnapshotBuffer(
+    context.repository,
+    path,
+    context.commitSha,
+    readmeByteLimit,
+    "manifest-invalid",
+  );
+  const readmeBaseUrl = rawUrl(context.repository, context.commitSha, "").replace(/\/$/, "");
+  const html = renderReadmeHtml(buffer.toString("utf8"), readmeBaseUrl);
+  if (!html.trim()) return null;
+  const fileBase = previewFileBase(context.repository);
+  const fileName = `${fileBase}.html`;
+  return { fileName, html };
+}
+
+async function stageSnapshotReadme(snapshot, stageDirectory) {
+  if (!snapshot) return;
+  await writeFile(resolve(stageDirectory, snapshot.fileName), snapshot.html);
 }
 
 export async function validateBeforeStagingPreview({
@@ -1202,28 +1291,57 @@ async function prunePreviewStage(stageDirectory, plugins) {
   }
 }
 
+async function pruneReadmeStage(stageDirectory, plugins) {
+  const referenced = new Set();
+  for (const plugin of plugins) {
+    const value = plugin.readmeHtml;
+    if (typeof value === "string" && value.startsWith("assets/readme/")) {
+      referenced.add(value.slice("assets/readme/".length));
+    }
+  }
+  for (const existing of await readdir(stageDirectory)) {
+    if (!referenced.has(existing)) await unlink(resolve(stageDirectory, existing));
+  }
+}
+
 async function commitGeneratedFiles(stageDirectory, serializedCatalog, options = {}) {
   const targetCatalogPath = options.catalogPath || catalogPath;
   const targetPreviewDirectory = options.previewDirectory || previewDirectory;
+  const targetReadmeDirectory = options.readmeDirectory || readmeDirectory;
   const catalogTemp = `${targetCatalogPath}.tmp-${process.pid}`;
   const previewBackup = `${targetPreviewDirectory}.backup-${process.pid}`;
+  const readmeBackup = `${targetReadmeDirectory}.backup-${process.pid}`;
   await writeFile(catalogTemp, serializedCatalog);
   let movedPreview = false;
+  let movedReadme = false;
   try {
     await rm(previewBackup, { recursive: true, force: true });
+    await rm(readmeBackup, { recursive: true, force: true });
     try {
       await rename(targetPreviewDirectory, previewBackup);
       movedPreview = true;
     } catch (error) {
       if (error.code !== "ENOENT") throw error;
     }
+    try {
+      await rename(targetReadmeDirectory, readmeBackup);
+      movedReadme = true;
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
     await rename(stageDirectory, targetPreviewDirectory);
+    if (options.readmeStageDirectory) {
+      await rename(options.readmeStageDirectory, targetReadmeDirectory);
+    }
     await rename(catalogTemp, targetCatalogPath);
     await rm(previewBackup, { recursive: true, force: true });
+    await rm(readmeBackup, { recursive: true, force: true });
   } catch (error) {
     await rm(catalogTemp, { force: true });
     await rm(targetPreviewDirectory, { recursive: true, force: true });
+    await rm(targetReadmeDirectory, { recursive: true, force: true });
     if (movedPreview) await rename(previewBackup, targetPreviewDirectory);
+    if (movedReadme) await rename(readmeBackup, targetReadmeDirectory);
     throw error;
   }
 }
@@ -1275,6 +1393,11 @@ export async function buildCatalog(options = {}) {
   await mkdir(activePreviewParent, { recursive: true });
   const stageDirectory = await mkdtemp(resolve(activePreviewParent, ".plugins-stage-"));
   await seedPreviewStage(stageDirectory, activePreviewDirectory);
+  const activeReadmeDirectory = options.readmeDirectory || readmeDirectory;
+  const activeReadmeParent = dirname(activeReadmeDirectory);
+  await mkdir(activeReadmeParent, { recursive: true });
+  const readmeStageDirectory = await mkdtemp(resolve(activeReadmeParent, ".readme-stage-"));
+  await seedPreviewStage(readmeStageDirectory, activeReadmeDirectory);
 
   try {
     for (const source of registry.sources || []) {
@@ -1313,6 +1436,20 @@ export async function buildCatalog(options = {}) {
           sourcePlan.incremental,
         );
         validateRepositoryDocs(context);
+        let readmeHtmlPath = "";
+        try {
+          const readmeSnapshot = await loadSnapshotReadme(source, context);
+          if (readmeSnapshot) {
+            await stageSnapshotReadme(readmeSnapshot, readmeStageDirectory);
+            readmeHtmlPath = `assets/readme/${readmeSnapshot.fileName}`;
+          }
+        } catch (readmeError) {
+          if (readmeError instanceof CatalogCheckError) {
+            console.error(`${source.repo}: readme fetch skipped (${readmeError.code})`);
+          } else {
+            console.error(`${source.repo}: readme fetch failed`);
+          }
+        }
         const discovered = await validateBeforeStagingPreview({
           loadPreview: () => loadSnapshotPreview(source, context),
           validateSource: (preview) => (
@@ -1325,7 +1462,7 @@ export async function buildCatalog(options = {}) {
           stagePreview: (snapshot) => stageSnapshotPreview(snapshot, stageDirectory),
         });
         plugins.push(...discovered.map((plugin) => successfulState(
-          plugin,
+          { ...plugin, ...(readmeHtmlPath ? { readmeHtml: readmeHtmlPath } : {}) },
           source,
           context,
           previousById.get(plugin.id),
@@ -1386,6 +1523,7 @@ export async function buildCatalog(options = {}) {
       throw new Error("Catalog contains duplicate plugin IDs");
     }
     await prunePreviewStage(stageDirectory, plugins);
+    await pruneReadmeStage(readmeStageDirectory, plugins);
     const projectedCatalog = projectCatalogVerification(registry, { plugins });
     const nextContent = {
       stateSchemaVersion: 2,
@@ -1408,6 +1546,8 @@ export async function buildCatalog(options = {}) {
     await commitGeneratedFiles(stageDirectory, serialized, {
       catalogPath: activeCatalogPath,
       previewDirectory: activePreviewDirectory,
+      readmeDirectory: activeReadmeDirectory,
+      readmeStageDirectory,
     });
     console.log(
       `${changed ? "Updated" : "Validated"} ${plugins.length} plugins from ${
@@ -1416,6 +1556,7 @@ export async function buildCatalog(options = {}) {
     );
   } catch (error) {
     await rm(stageDirectory, { recursive: true, force: true });
+    await rm(readmeStageDirectory, { recursive: true, force: true });
     throw error;
   }
 }

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1307,3 +1307,27 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   html { scroll-behavior: auto; }
   *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
 }
+.readme-section { padding: 28px 0; }
+.readme-section h2 { margin: 0 0 14px; }
+.readme-content { padding: 15px; border: 1px dashed var(--line); background: var(--panel); max-width: 100%; overflow-x: auto; }
+.readme-content > *:first-child { margin-top: 0; }
+.readme-content > *:last-child { margin-bottom: 0; }
+.readme-content h1, .readme-content h2, .readme-content h3, .readme-content h4 { margin: 18px 0 8px; font-size: 15px; color: var(--text); }
+.readme-content h1 { font-size: 18px; }
+.readme-content h2 { font-size: 16px; }
+.readme-content p { margin: 0 0 12px; color: var(--muted); line-height: 1.6; }
+.readme-content ul, .readme-content ol { margin: 0 0 12px; padding-left: 20px; color: var(--muted); line-height: 1.6; }
+.readme-content li { margin: 3px 0; }
+.readme-content pre { margin: 0 0 12px; padding: 12px 14px; border: 1px solid var(--line); background: var(--panel-2); overflow-x: auto; }
+.readme-content pre code { color: var(--text); font-size: 13px; line-height: 1.5; }
+.readme-content code { font-family: var(--mono); font-size: 13px; }
+.readme-content :not(pre) > code { padding: 1px 5px; border: 1px solid var(--line-soft); background: var(--panel-2); color: var(--text); }
+.readme-content a { color: var(--accent); text-decoration: none; }
+.readme-content a:hover { text-decoration: underline; }
+.readme-content img { max-width: 100%; height: auto; border: 1px solid var(--line); display: block; margin: 0 0 12px; }
+.readme-content blockquote { margin: 0 0 12px; padding: 2px 0 2px 14px; border-left: 2px solid var(--line-strong); color: var(--muted); }
+.readme-content table { border-collapse: collapse; width: 100%; margin: 0 0 12px; }
+.readme-content th, .readme-content td { border: 1px solid var(--line); padding: 6px 10px; text-align: left; color: var(--muted); }
+.readme-content th { color: var(--text); }
+.readme-content hr { border: none; border-top: 1px solid var(--line); margin: 16px 0; }
+.readme-loading { color: var(--muted); font-size: 14px; }

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,14 +25,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260827-01";
+} from "./shared.js?v=20260828-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260827-01";
+} from "./engagement.js?v=20260828-01";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -59,7 +59,7 @@ import {
   searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260827-01";
+} from "./search.js?v=20260828-01";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260827-01";
+} from "./shared.js?v=20260828-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260827-01";
+} from "./shared.js?v=20260828-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260827-01";
+} from "./engagement.js?v=20260828-01";
 
 function safeGitHubWebUrl(value) {
   try {
@@ -307,6 +307,7 @@ export function detailTemplate(plugin, engagement, {
         </div>` : ""}
       </header>
       <p class="detail-description">${escapeHtml(plugin.description)}</p>${preview}<div class="plugin-tags">${tags}</div>
+      ${plugin.readmeHtml ? `<section class="detail-section readme-section" id="readme"><h2>Readme</h2><div class="readme-content" data-readme-url="${escapeHtml(plugin.readmeHtml)}" role="status" aria-live="polite"><p class="readme-loading">Loading readme…</p></div></section>` : ""}
       <section class="detail-section${isThirdPartyListing ? " detail-section-before-verification" : ""}" id="install"><h2>${plugin.builtIn ? escapeHtml(plugin.officialCommandLabel) : availabilityHeading}</h2>${install}</section>
       ${verificationStatusSection}
       ${securityNoticeSection}
@@ -323,6 +324,22 @@ function showDetailError({ title, message, crumb }) {
   error.querySelector("p").textContent = message;
   document.querySelector("#crumb-name").textContent = crumb;
   document.title = `${title} | Omarchy Plugins`;
+}
+
+async function loadReadmeContent(content, plugin) {
+  const container = content.querySelector("[data-readme-url]");
+  if (!container) return;
+  const url = container.dataset.readmeUrl;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`readme fetch returned ${response.status}`);
+    const html = await response.text();
+    if (!html.trim()) throw new Error("readme is empty");
+    container.innerHTML = html;
+  } catch {
+    const section = container.closest(".readme-section");
+    if (section) section.remove();
+  }
 }
 
 async function init() {
@@ -377,8 +394,10 @@ async function init() {
     setupControlTooltips(content);
     setupDetailMetaLineStarts(content);
     setupPreviewLightbox(content, document.querySelector("#preview-lightbox"));
+    loadReadmeContent(content, plugin);
     document.querySelector("#aside-verification-link").hidden = !content.querySelector("#verification");
     document.querySelector("#aside-security-link").hidden = !content.querySelector("#security");
+    document.querySelector("#aside-readme-link").hidden = !content.querySelector("#readme");
     if (currentHashId() === "trust") {
       const url = new URL(location.href);
       url.hash = "terms";

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260827-01";
+} from "./shared.js?v=20260828-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260827-01"></script>
+    <script type="module" src="assets/js/develop.js?v=20260828-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260827-01"></script>
+    <script type="module" src="assets/js/app.js?v=20260828-01"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -30,13 +30,13 @@
         </main>
       </div>
       <aside class="right-aside">
-        <div class="aside-block"><span class="aside-title">On this page</span><a class="aside-link active" href="#overview">Overview</a><a class="aside-link" id="aside-install-link" href="#install">Install</a><a class="aside-link" id="aside-verification-link" href="#verification" hidden>Verification status</a><a class="aside-link" id="aside-security-link" href="#security" hidden>Security Notice</a><a class="aside-link" href="#terms">Terms of Use</a></div>
+        <div class="aside-block"><span class="aside-title">On this page</span><a class="aside-link active" href="#overview">Overview</a><a class="aside-link" id="aside-readme-link" href="#readme" hidden>Readme</a><a class="aside-link" id="aside-install-link" href="#install">Install</a><a class="aside-link" id="aside-verification-link" href="#verification" hidden>Verification status</a><a class="aside-link" id="aside-security-link" href="#security" hidden>Security Notice</a><a class="aside-link" href="#terms">Terms of Use</a></div>
         <div class="aside-block"><span class="aside-title">Metadata</span><dl class="aside-meta"><div><dt>Availability</dt><dd id="aside-status">—</dd></div><div id="aside-verification-row"><dt>Verification</dt><dd id="aside-verification">—</dd></div><div><dt>Version</dt><dd id="aside-version">—</dd></div><div><dt>License</dt><dd id="aside-license">—</dd></div><div><dt>Owner</dt><dd id="aside-owner">—</dd></div></dl></div>
       </aside>
     </div>
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260827-01"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260828-01"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260827-01"></script>
+    <script type="module" src="assets/js/publish.js?v=20260828-01"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1168,12 +1168,12 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260827-01");
+  assert.equal(keys[0], "20260828-01");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
   assert.equal(new Set(styleKeys).size, 1);
-  assert.equal(styleKeys[0], "20260820-21");
+  assert.equal(styleKeys[0], "20260828-01");
   const faviconKeys = [files.index, files.plugin, files.publish, files.develop]
     .map((html) => html.match(/favicon\.svg\?v=([^"']+)/)?.[1]);
   assert.ok(faviconKeys.every(Boolean));

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -17,6 +17,9 @@ import {
   githubApiFailure,
   parseGitHubRepository,
   readLimitedBuffer,
+  readmeByteLimit,
+  readmeRenderedLimit,
+  renderReadmeHtml,
   repositoryReleaseForRefresh,
   snapshotHttpErrorCode,
   successfulState,
@@ -1262,4 +1265,50 @@ test("SHIBUMI is listed once as a manual shell suite", () => {
   assert.equal(shibumi.installCommand, "");
   assert.match(shibumi.previewImage, /^assets\/img\/plugins\/.*-detail\.webp$/);
   assert.match(shibumi.previewThumbnail, /^assets\/img\/plugins\/.*-card\.webp$/);
+});
+
+test("renderReadmeHtml strips scripts, event handlers, and javascript: URLs", () => {
+  const markdown = [
+    "# Title",
+    "",
+    "<script>alert(1)</script>",
+    "",
+    '<img src="javascript:alert(1)" alt="bad">',
+    "",
+    '<img src="https://example.com/ok.png" alt="ok" onerror="alert(1)">',
+    "",
+    '[bad](javascript:alert(1))',
+    "",
+    '[ok](https://example.com)',
+    "",
+    '```bash\nomarchy plugin enable foo\n```',
+    "",
+    '<iframe src="https://evil.com"></iframe>',
+    "",
+    '<a href="data:text/html,<script>alert(1)</script>">data</a>',
+  ].join("\n");
+
+  const html = renderReadmeHtml(markdown);
+
+  assert.doesNotMatch(html, /<script[\s>]/i);
+  assert.doesNotMatch(html, /onerror/i);
+  assert.doesNotMatch(html, /javascript:/i);
+  assert.doesNotMatch(html, /<iframe[\s>]/i);
+  assert.doesNotMatch(html, /data:text\/html/i);
+  assert.match(html, /<h1[^>]*>Title<\/h1>/i);
+  assert.match(html, /<img[^>]*src="https:\/\/example\.com\/ok\.png"[^>]*alt="ok"/i);
+  assert.match(html, /<a[^>]*href="https:\/\/example\.com"[^>]*>ok<\/a>/i);
+  assert.match(html, /<pre><code[^>]*>omarchy plugin enable foo/);
+  assert.match(html, /target="_blank"/);
+  assert.match(html, /rel="noreferrer"/);
+});
+
+test("renderReadmeHtml returns empty string for empty input", () => {
+  assert.equal(renderReadmeHtml("").trim(), "");
+  assert.equal(renderReadmeHtml(null).trim(), "");
+});
+
+test("readme byte and rendered limits are exported and positive", () => {
+  assert.ok(readmeByteLimit > 0);
+  assert.ok(readmeRenderedLimit > readmeByteLimit);
 });

--- a/test/plugin-detail-rendering.test.js
+++ b/test/plugin-detail-rendering.test.js
@@ -303,3 +303,16 @@ test("suite listings do not offer the unsupported verification workflow", () => 
   assert.match(html, /Verification unavailable:<\/strong> Suite listings are outside the plugin verification workflow\./);
   assert.doesNotMatch(html, /Snapshot verified:|Snapshot unverified:|Update unverified:|Contributor action:|plugin verification form|detail-verification/);
 });
+
+test("readme section renders when readmeHtml is present", () => {
+  const html = render({ readmeHtml: "assets/readme/example-community-plugin.html" });
+  assert.match(html, /<section class="detail-section readme-section" id="readme">[\s\S]*<h2>Readme<\/h2>/);
+  assert.match(html, /data-readme-url="assets\/readme\/example-community-plugin\.html"/);
+  assert.match(html, /Loading readme…/);
+});
+
+test("readme section is absent when readmeHtml is missing", () => {
+  const html = render();
+  assert.doesNotMatch(html, /id="readme"/);
+  assert.doesNotMatch(html, /readme-section/);
+});


### PR DESCRIPTION
Fetch upstream README at build time, render markdown to HTML with marked, sanitize with sanitize-html (strips scripts, event handlers, javascript: URLs), and write per-plugin files to site/assets/readme/. The plugin detail page lazy-loads the sanitized HTML into a Readme section. Relative image and link URLs are rewritten to absolute raw.githubusercontent.com URLs.
<img width="1885" height="865" alt="image" src="https://github.com/user-attachments/assets/07d99e8a-ad19-4e46-8f97-87036bdebb13" />