### PR TITLE
Make category filters scrollable horizontally

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -883,12 +883,26 @@ html:has(.preview-lightbox[open]) { overflow: hidden; scrollbar-gutter: stable; 
 .source-button span:last-child { margin-left: 7px; color: var(--muted); font-weight: 600; }
 .source-button.active { border-color: var(--accent); background: var(--accent); color: var(--accent-contrast); }
 .source-button.active span:last-child { color: var(--accent-contrast); }
-.category-list { display: flex; flex: 1; flex-wrap: wrap; gap: 4px; }
+.category-list { display: flex; flex: 1; flex-wrap: nowrap; gap: 4px; overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+.category-list::-webkit-scrollbar { display: none; }
+.category-list::before {
+  content: ""; position: sticky; left: 0; flex-shrink: 0; width: 12px; min-height: 29px;
+  background: linear-gradient(to right, var(--panel), transparent); z-index: 1; margin-right: -12px; pointer-events: none;
+}
+.category-list::after {
+  content: ""; position: sticky; right: 0; flex-shrink: 0; width: 12px; min-height: 29px;
+  background: linear-gradient(to left, var(--panel), transparent); z-index: 1; margin-left: -12px; pointer-events: none;
+}
 .category-button {
-  width: auto; min-height: 29px; padding: 0 9px; border: 1px solid var(--line); background: var(--code-bg);
+  flex-shrink: 0; white-space: nowrap; width: auto; min-height: 29px; padding: 0 9px; border: 1px solid var(--line); background: var(--code-bg);
   color: var(--muted); font-family: var(--mono); font-size: 11px; font-weight: 600;
   line-height: 1; letter-spacing: .025em; text-transform: uppercase;
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease, transform 100ms ease;
 }
+@media (hover: hover) and (pointer: fine) {
+  .category-button:hover { color: var(--text); border-color: var(--line-strong); }
+}
+.category-button:active { transform: scale(0.97); transform-origin: center; }
 .category-button span:last-child { margin-left: 6px; color: var(--text); font-size: 11px; font-weight: 500; }
 .category-button.active {
   border-color: var(--line-strong); background: var(--panel-2); color: var(--text);


### PR DESCRIPTION
Replace wrapping layout with horizontal scroll. Add edge fade overlays with pointer-events: none, hover/active states on filter buttons gated to pointer devices, and overscroll containment.

Before:
<img width="1435" height="456" alt="image" src="https://github.com/user-attachments/assets/57015d23-127d-43a5-aa27-1c48aa42b999" />
After:
<img width="1290" height="312" alt="image" src="https://github.com/user-attachments/assets/2404484d-2207-4a59-b0ae-b76f0880e1ea" />