### PR TITLE
Add type-to-jump page input in pagination

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1110,6 +1110,12 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 .pagination-summary strong {
   color: var(--text); font-size: 11px; font-weight: 700; letter-spacing: .04em;
 }
+.page-input {
+  width: 20px; border: 0; background: transparent; padding: 0; margin: 0;
+  color: inherit; font: inherit; text-align: center; text-transform: none;
+}
+.page-input:focus { outline: 1px solid var(--accent); }
+.page-input::placeholder { color: var(--muted); }
 .pagination-direction {
   color: var(--muted); font-family: var(--mono); font-size: 10px; font-weight: 700;
   letter-spacing: .1em; text-transform: uppercase;

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -166,7 +166,8 @@ const previousPage = document.querySelector("#page-previous");
 const nextPage = document.querySelector("#page-next");
 const previousPageLabel = document.querySelector("#page-previous-label");
 const nextPageLabel = document.querySelector("#page-next-label");
-const pageSummary = document.querySelector("#page-summary");
+const pageInput = document.querySelector("#page-input");
+const pageTotal = document.querySelector("#page-total");
 const viewToggle = document.querySelector("#catalog-view-toggle");
 const viewButton = document.querySelector("#catalog-view-button");
 const viewLabel = document.querySelector("#catalog-view-label");
@@ -915,7 +916,8 @@ function renderPagination(totalItems, pageState) {
   nextPage.disabled = !pageState.hasNext;
   previousPageLabel.textContent = pageState.hasPrevious ? `Page ${pageState.page - 1}` : "First page";
   nextPageLabel.textContent = pageState.hasNext ? `Page ${pageState.page + 1}` : "Last page";
-  pageSummary.textContent = `${pageState.page} / ${pageState.totalPages}`;
+  pageTotal.textContent = pageState.totalPages;
+  if (document.activeElement !== pageInput) pageInput.value = pageState.page;
   previousPage.setAttribute("aria-label", pageState.hasPrevious
     ? `Go to plugin page ${pageState.page - 1}`
     : "No previous plugin page");
@@ -1511,6 +1513,20 @@ async function init() {
   });
   nextPage.addEventListener("click", () => {
     if (!nextPage.disabled) changePage(1);
+  });
+  pageInput.addEventListener("change", () => {
+    const page = Number.parseInt(pageInput.value, 10);
+    if (!Number.isFinite(page) || page < 1) { pageInput.value = state.page; return; }
+    const visible = filteredPlugins();
+    const maxPage = Math.max(1, Math.ceil(visible.length / pluginsPerPage));
+    const clamped = Math.min(page, maxPage);
+    if (clamped === state.page) { pageInput.value = state.page; return; }
+    state.page = clamped;
+    render({ historyMode: "push", announce: true });
+    const firstResult = grid.querySelector(".plugin-card-link");
+    firstResult?.focus({ preventScroll: true });
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    grid.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "start" });
   });
   viewButton.addEventListener("click", () => {
     const previousScrollTop = window.scrollY;

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -132,8 +132,8 @@
             <span class="pagination-direction"><span aria-hidden="true">←</span> Previous</span>
             <span id="page-previous-label" class="pagination-target">First page</span>
           </button>
-          <span class="pagination-summary" aria-hidden="true">
-            <span>Page</span><strong id="page-summary">1 / 1</strong>
+          <span class="pagination-summary">
+            <span>Page</span><strong><input id="page-input" class="page-input" type="text" inputmode="numeric" pattern="[0-9]*" aria-label="Go to page" title="Type a page number" value="1"> / <span id="page-total">1</span></strong>
           </span>
           <button id="page-next" class="pagination-button pagination-next" type="button">
             <span class="pagination-direction">Next <span aria-hidden="true">→</span></span>
@@ -185,6 +185,6 @@
       <a href="https://github.com/HANCORE-linux/omarchy-plugin-marketplace"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1 1.6 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.7-1.3-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.7 9.7 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.8v2.7c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z"/></svg>GitHub</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260827-01"></script>
+    <script type="module" src="assets/js/app.js?v=20260828-01"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>


### PR DESCRIPTION
Replace static page summary with an editable input so users can type a page number directly. Bumps CSS and app.js cache versions.
<img width="1401" height="203" alt="image" src="https://github.com/user-attachments/assets/2dad5e5f-5947-4303-8cec-8696de07ad86" />