### PR TITLE
Make breadcrumb Plugins link clickable with hover/active states

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -168,7 +168,12 @@ svg {
   backdrop-filter: blur(12px); align-items: center; justify-content: space-between;
 }
 .crumbs { overflow: hidden; color: var(--muted); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-.crumbs b { color: var(--text); font-weight: 500; }
+.crumbs b { color: var(--accent); font-weight: 500; }
+.crumbs a { color: var(--muted); text-decoration: none; transition: color 150ms ease, transform 100ms ease; }
+@media (hover: hover) and (pointer: fine) {
+  .crumbs a:hover { color: var(--accent); }
+}
+.crumbs a:active { transform: scale(0.97); }
 .top-actions { display: flex; height: 100%; align-items: center; }
 .square-action {
   display: inline-flex; height: 32px; padding: 0 13px; border: 1px solid var(--line);
@@ -1211,7 +1216,7 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   .left-sidebar, .right-aside { display: none; }
   .doc-topbar { padding: 0 12px; }
   .crumbs { max-width: 110px; color: var(--text); text-transform: uppercase; }
-  .crumbs span { display: none; }
+  .crumb-prefix { display: none; }
   .top-actions .desktop-only { display: none; }
   .page-content { width: auto; padding: 25px 18px calc(92px + env(safe-area-inset-bottom)); }
   .page-header h1 { font-size: 28px; }

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260828-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -21,7 +21,7 @@
       </aside>
       <div class="center-panel">
         <header class="doc-topbar">
-          <div class="crumbs"><span>Omarchy / Plugins / </span><b id="crumb-name">Loading…</b></div>
+          <div class="crumbs"><span class="crumb-prefix">Omarchy / </span><a href="index.html" class="crumb-link">Plugins</a><span> / </span><b id="crumb-name">Loading…</b></div>
           <div class="top-actions"><a class="square-action desktop-only" href="index.html">Browse</a><button class="square-action icon-only theme-toggle" type="button" aria-label="Toggle theme"><svg class="sun-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2"/></svg><svg class="moon-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 15.2A8.5 8.5 0 0 1 8.8 4a8.5 8.5 0 1 0 11.2 11.2Z"/></svg></button></div>
         </header>
         <main id="plugin-detail" class="page-content" tabindex="-1">

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260828-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>


### PR DESCRIPTION
Link "Plugins" back to marketplace, highlight current page name in accent color, add hover/active transitions gated to pointer devices. Fix mobile wayfinding by hiding only the prefix, not the link.
<img width="312" height="80" alt="image" src="https://github.com/user-attachments/assets/cee94752-9052-4df2-bf2c-f21cff250502" />
