### PR TITLE
Require complete Explorer history

### DIFF
--- a/scripts/build-explorer-data.mjs
+++ b/scripts/build-explorer-data.mjs
@@ -1,12 +1,19 @@
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import {
+  assertCompleteGitHistory,
+  assertGrowthContinuity,
+  readCommittedExplorerData,
+} from "./explorer-growth-history.mjs";
 
 const catalogUrl = new URL("../site/catalog.json", import.meta.url);
 const outputUrl = new URL("../site/explorer-data.json", import.meta.url);
 const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 const catalog = JSON.parse(fs.readFileSync(catalogUrl, "utf8"));
 const plugins = catalog.plugins.filter((plugin) => plugin.sourceType === "community");
+
+assertCompleteGitHistory(projectRoot);
 
 const clusterDefinitions = [
   ["ai", "AI & Automation", "#a78bfa", [" ai ", "llm", "gpt", "claude", "ollama", "agent", "assistant", "openai", "automation"]],
@@ -321,37 +328,9 @@ function historicalCatalogGrowth() {
   };
 }
 
-function reconstructedCatalogGrowth() {
-  const listingDates = plugins.map((plugin) => String(plugin.listedAt || plugin.addedAt).slice(0, 10)).sort();
-  const dailyCounts = new Map();
-  for (const date of listingDates) dailyCounts.set(date, (dailyCounts.get(date) || 0) + 1);
-  const snapshots = [];
-  let total = 0;
-  for (const date of [...dailyCounts.keys()].sort()) {
-    total += dailyCounts.get(date);
-    snapshots.push({ date, total });
-  }
-  const catalogDate = String(catalog.generatedAt || listingDates.at(-1)).slice(0, 10);
-  if (!snapshots.some((snapshot) => snapshot.date === catalogDate)) snapshots.push({ date: catalogDate, total });
-  return {
-    growth: dailySeries(snapshots),
-    meta: {
-      method: "current-catalog-listing-dates",
-      label: "Reconstructed from current catalog metadata",
-      detail: "Cumulative listing dates from currently active plugins; delisted plugins are not represented.",
-      timezone: "UTC",
-      historical: false,
-    },
-  };
-}
-
-let growthResult;
-try {
-  growthResult = historicalCatalogGrowth();
-} catch (error) {
-  console.warn(`Explorer growth fallback: ${error.message}`);
-  growthResult = reconstructedCatalogGrowth();
-}
+const growthResult = historicalCatalogGrowth();
+const committedExplorer = readCommittedExplorerData(projectRoot);
+assertGrowthContinuity(committedExplorer, growthResult.growth, catalog.generatedAt);
 
 const output = {
   generatedAt: catalog.generatedAt,

--- a/scripts/explorer-growth-history.mjs
+++ b/scripts/explorer-growth-history.mjs
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+
+const historicalMethod = "git-catalog-snapshots";
+const dayMilliseconds = 86_400_000;
+
+function utcDayNumber(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error("Explorer growth contains an invalid UTC day");
+  }
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString().slice(0, 10) !== value) {
+    throw new Error("Explorer growth contains an invalid UTC day");
+  }
+  return timestamp / dayMilliseconds;
+}
+
+function generatedUtcDay(value) {
+  if (typeof value !== "string") throw new Error("Explorer growth has an invalid generatedAt timestamp");
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString() !== value) {
+    throw new Error("Explorer growth has an invalid generatedAt timestamp");
+  }
+  return value.slice(0, 10);
+}
+
+function assertGrowthSeries(growth) {
+  if (!Array.isArray(growth) || growth.length === 0) {
+    throw new Error("Explorer growth must contain a historical series");
+  }
+  let previousDay;
+  let previousTotal = 0;
+  for (const point of growth) {
+    if (!point || Object.keys(point).sort().join(",") !== "added,date,total"
+      || !Number.isInteger(point.total)
+      || point.total < 0
+      || !Number.isInteger(point.added)) {
+      throw new Error("Explorer growth contains an invalid historical point");
+    }
+    const day = utcDayNumber(point.date);
+    if ((previousDay !== undefined && day !== previousDay + 1)
+      || point.added !== point.total - previousTotal) {
+      throw new Error("Explorer growth is not a contiguous daily series");
+    }
+    previousDay = day;
+    previousTotal = point.total;
+  }
+}
+
+function sameGrowthPoint(first, second) {
+  return first.date === second.date
+    && first.total === second.total
+    && first.added === second.added;
+}
+
+export function assertCompleteGitHistory(projectRoot) {
+  let shallowState;
+  try {
+    shallowState = execFileSync(
+      "git",
+      ["rev-parse", "--is-shallow-repository"],
+      { cwd: projectRoot, encoding: "utf8" },
+    ).trim();
+  } catch {
+    throw new Error("Explorer growth requires complete Git history");
+  }
+  if (shallowState !== "false") {
+    throw new Error("Explorer growth requires complete Git history (shallow repository detected)");
+  }
+}
+
+export function readCommittedExplorerData(projectRoot) {
+  const source = execFileSync(
+    "git",
+    ["show", "HEAD:site/explorer-data.json"],
+    { cwd: projectRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  return JSON.parse(source);
+}
+
+export function assertGrowthContinuity(previousExplorer, nextGrowth, generatedAt) {
+  if (previousExplorer?.growthMeta?.method !== historicalMethod) {
+    throw new Error("Explorer growth does not extend the committed historical series");
+  }
+  const previousGrowth = previousExplorer.growth;
+  const previousDate = generatedUtcDay(previousExplorer.generatedAt);
+  const currentDate = generatedUtcDay(generatedAt);
+  assertGrowthSeries(previousGrowth);
+  assertGrowthSeries(nextGrowth);
+
+  const elapsedDays = utcDayNumber(currentDate) - utcDayNumber(previousDate);
+  if (elapsedDays < 0
+    || nextGrowth.length !== previousGrowth.length + elapsedDays
+    || previousGrowth.at(-1).date !== previousDate
+    || nextGrowth.at(-1).date !== currentDate) {
+    throw new Error("Explorer growth does not extend the committed historical series");
+  }
+
+  const mutableIndex = elapsedDays === 0 ? previousGrowth.length - 1 : -1;
+  for (let index = 0; index < previousGrowth.length; index++) {
+    if (index === mutableIndex) {
+      if (nextGrowth[index]?.date !== currentDate) {
+        throw new Error("Explorer growth changed the current UTC day boundary");
+      }
+    } else if (!sameGrowthPoint(previousGrowth[index], nextGrowth[index])) {
+      throw new Error("Explorer growth changed or removed a completed UTC day");
+    }
+  }
+}

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import {
+  assertCompleteGitHistory,
+  assertGrowthContinuity,
+} from "../scripts/explorer-growth-history.mjs";
 import {
   matchesExplorerSearch,
   repositoryPublisher,
@@ -26,6 +33,38 @@ function workflowJobSource(workflow, name, nextName = "") {
   assert.ok(start > 0, `${name} job must exist`);
   const end = nextName ? workflow.indexOf(`\n  ${nextName}:\n`, start + 1) : -1;
   return end > start ? workflow.slice(start, end) : workflow.slice(start);
+}
+
+function createExplorerBuilderFixture(growth) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "explorer-builder-history-"));
+  fs.mkdirSync(path.join(directory, "scripts"));
+  fs.mkdirSync(path.join(directory, "site"));
+  fs.copyFileSync(new URL("../scripts/build-explorer-data.mjs", import.meta.url), path.join(directory, "scripts", "build-explorer-data.mjs"));
+  fs.copyFileSync(new URL("../scripts/explorer-growth-history.mjs", import.meta.url), path.join(directory, "scripts", "explorer-growth-history.mjs"));
+  fs.writeFileSync(path.join(directory, "site", "catalog.json"), JSON.stringify({
+    generatedAt: "2026-08-28T10:00:00.000Z",
+    plugins: [],
+  }));
+  fs.writeFileSync(path.join(directory, "site", "explorer-data.json"), JSON.stringify({
+    generatedAt: "2026-08-28T10:00:00.000Z",
+    growthMeta: { method: "git-catalog-snapshots" },
+    growth,
+  }));
+  execFileSync("git", ["init", "--quiet"], { cwd: directory });
+  execFileSync("git", ["add", "."], { cwd: directory });
+  execFileSync("git", [
+    "-c", "user.name=Explorer Test",
+    "-c", "user.email=explorer-test@example.invalid",
+    "commit", "--quiet", "-m", "Add Explorer fixture",
+  ], {
+    cwd: directory,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: "2026-08-28T09:00:00Z",
+      GIT_COMMITTER_DATE: "2026-08-28T09:00:00Z",
+    },
+  });
+  return directory;
 }
 
 test("explorer data covers the current community catalog", () => {
@@ -58,7 +97,125 @@ test("growth series uses daily end-of-day catalog history snapshots", () => {
   }
   assert.equal(explorer.growth.at(-1).total, explorer.nodes.length);
   assert.equal(explorer.growth.at(-1).date, catalog.generatedAt.slice(0, 10));
-  assert.match(builder, /git[\s\S]*site\/catalog\.json[\s\S]*current-catalog-listing-dates/);
+  assert.match(builder, /assertCompleteGitHistory\(projectRoot\)[\s\S]*historicalCatalogGrowth\(\)/);
+  assert.doesNotMatch(builder, /current-catalog-listing-dates|Explorer growth fallback/);
+});
+
+test("Explorer growth rejects shallow Git history", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "explorer-growth-history-"));
+  try {
+    execFileSync("git", ["init", "--quiet"], { cwd: directory });
+    fs.writeFileSync(path.join(directory, "fixture.txt"), "fixture\n");
+    execFileSync("git", ["add", "fixture.txt"], { cwd: directory });
+    execFileSync("git", [
+      "-c", "user.name=Explorer Test",
+      "-c", "user.email=explorer-test@example.invalid",
+      "commit", "--quiet", "-m", "Add fixture",
+    ], { cwd: directory });
+    assert.doesNotThrow(() => assertCompleteGitHistory(directory));
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).trim();
+    fs.writeFileSync(path.join(directory, ".git", "shallow"), `${head}\n`);
+    assert.throws(
+      () => assertCompleteGitHistory(directory),
+      /complete Git history \(shallow repository detected\)/,
+    );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("Explorer growth only changes the current day or appends valid later days", () => {
+  const previous = {
+    generatedAt: "2026-08-28T10:00:00.000Z",
+    growthMeta: { method: "git-catalog-snapshots" },
+    growth: [
+      { date: "2026-08-27", total: 10, added: 10 },
+      { date: "2026-08-28", total: 12, added: 2 },
+    ],
+  };
+  const sameDay = [
+    previous.growth[0],
+    { date: "2026-08-28", total: 13, added: 3 },
+  ];
+  const nextDay = [
+    ...previous.growth,
+    { date: "2026-08-29", total: 11, added: -1 },
+  ];
+
+  assert.doesNotThrow(() => assertGrowthContinuity(previous, sameDay, "2026-08-28T18:00:00.000Z"));
+  assert.doesNotThrow(() => assertGrowthContinuity(previous, nextDay, "2026-08-29T04:17:00.000Z"));
+  assert.throws(
+    () => assertGrowthContinuity(previous, [
+      { date: "2026-08-28", total: 12, added: 12 },
+      { date: "2026-08-29", total: 11, added: -1 },
+    ], "2026-08-29T04:17:00.000Z"),
+    /does not extend the committed historical series/,
+  );
+  assert.throws(
+    () => assertGrowthContinuity(previous, [
+      { date: "2026-08-27", total: 11, added: 11 },
+      { date: "2026-08-28", total: 12, added: 1 },
+      nextDay[2],
+    ], "2026-08-29T04:17:00.000Z"),
+    /changed or removed a completed UTC day/,
+  );
+  assert.throws(
+    () => assertGrowthContinuity(previous, [...previous.growth, {
+      date: "not-a-day", total: 12, added: 0,
+    }, {
+      date: "2026-08-30", total: 12, added: 0,
+    }], "2026-08-30T04:17:00.000Z"),
+    /invalid UTC day/,
+  );
+  assert.throws(
+    () => assertGrowthContinuity(previous, [
+      previous.growth[0],
+      { ...previous.growth[1], note: "unexpected" },
+    ], "2026-08-28T18:00:00.000Z"),
+    /invalid historical point/,
+  );
+  assert.throws(
+    () => assertGrowthContinuity(previous, previous.growth, "2026-08-27T18:00:00.000Z"),
+    /does not extend the committed historical series/,
+  );
+});
+
+test("Explorer builder fails closed for shallow and truncated repositories", () => {
+  const complete = createExplorerBuilderFixture([
+    { date: "2026-08-28", total: 0, added: 0 },
+  ]);
+  const truncated = createExplorerBuilderFixture([
+    { date: "2026-08-27", total: 0, added: 0 },
+    { date: "2026-08-28", total: 0, added: 0 },
+  ]);
+  try {
+    const completeResult = spawnSync(process.execPath, ["scripts/build-explorer-data.mjs"], {
+      cwd: complete,
+      encoding: "utf8",
+    });
+    assert.equal(completeResult.status, 0, completeResult.stderr);
+
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: complete, encoding: "utf8" }).trim();
+    fs.writeFileSync(path.join(complete, ".git", "shallow"), `${head}\n`);
+    const shallowResult = spawnSync(process.execPath, ["scripts/build-explorer-data.mjs"], {
+      cwd: complete,
+      encoding: "utf8",
+    });
+    assert.notEqual(shallowResult.status, 0);
+    assert.match(shallowResult.stderr, /complete Git history \(shallow repository detected\)/);
+
+    const previousOutput = fs.readFileSync(path.join(truncated, "site", "explorer-data.json"), "utf8");
+    const truncatedResult = spawnSync(process.execPath, ["scripts/build-explorer-data.mjs"], {
+      cwd: truncated,
+      encoding: "utf8",
+    });
+    assert.notEqual(truncatedResult.status, 0);
+    assert.match(truncatedResult.stderr, /does not extend the committed historical series/);
+    assert.equal(fs.readFileSync(path.join(truncated, "site", "explorer-data.json"), "utf8"), previousOutput);
+  } finally {
+    fs.rmSync(complete, { recursive: true, force: true });
+    fs.rmSync(truncated, { recursive: true, force: true });
+  }
 });
 
 test("explore page exposes graph and date-filtered growth views", () => {
@@ -226,6 +383,7 @@ test("catalog writers publish catalog and Explorer data as one checksummed trans
   ];
 
   for (const { name, workflow, producer, consumer } of writers) {
+    assert.match(producer, /fetch-depth: 0/, `${name} must check out complete catalog history`);
     assert.match(workflow, /explorer_sha:\s+\$\{\{ steps\.(?:bundle|catalog)\.outputs\.explorer_sha \}\}/, `${name} must expose the tested Explorer hash`);
     assert.match(producer, /cp site\/explorer-data\.json "\$bundle\/site\/explorer-data\.json"/, `${name} bundle must contain Explorer data`);
     assert.match(producer, /(?:find|sha256sum)[^\n]*site\/explorer-data\.json[^\n]*(?:\\\n[\s\S]*xargs -0 sha256sum|> SHA256SUMS)/, `${name} manifest must checksum Explorer data`);
@@ -244,7 +402,6 @@ test("catalog writers publish catalog and Explorer data as one checksummed trans
 
   assert.match(approvalWorkflow, /find registry\.json site\/catalog\.json site\/explorer-data\.json site\/assets\/img\/plugins -type f/);
   assert.match(refreshWorkflow, /find site\/catalog\.json site\/explorer-data\.json site\/assets\/img\/plugins -type f/);
-  assert.match(verificationWorkflow, /fetch-depth: 0/);
   const verificationProducer = workflowJobSource(verificationWorkflow, "analyze", "publish");
   assert.ok(verificationProducer.indexOf("node scripts/verify-listed-plugin.mjs") < verificationProducer.indexOf("run: npm run build:explorer"));
   assert.ok(verificationProducer.indexOf("run: npm run build:explorer") < verificationProducer.indexOf("run: npm test"));


### PR DESCRIPTION
## Summary

- fail closed when Explorer growth is built from a shallow Git checkout
- remove the reconstructed-history fallback from publication builds
- require the committed daily growth series to remain an exact historical prefix, while allowing same-day updates and later daily appends
- validate UTC dates, contiguous totals, delisting deltas, and complete-history workflow checkouts

## Verification

- `npm run build:explorer` (byte-identical output with complete history)
- `npm test` — 239/239 passed
- depth-1 and depth-200 reproductions now exit non-zero before replacing Explorer data
- Sandbox run `33175027451` passed the full, shallow, and non-shallow truncated-history fixtures

No new workflow, timer, bot, backend, label, or visible UI behavior is introduced.
