### PR TITLE
Improve Explorer label contrast and growth summary

### DIFF
--- a/site/assets/css/explore.css
+++ b/site/assets/css/explore.css
@@ -339,12 +339,18 @@
   border: 1px solid var(--growth-line); background: var(--growth-panel); grid-template-columns: 1.38fr 1fr;
 }
 .growth-summary::after { position: absolute; top: 49%; right: 0; left: 0; border-top: 1px solid var(--growth-line); content: ""; }
-.growth-summary > div { display: grid; min-width: 0; padding: 14px 16px; align-content: space-between; gap: 12px; }
+.growth-summary > div {
+  display: grid; min-width: 0; padding: 0 16px; grid-template-rows: 49% 51%; align-content: stretch; gap: 0;
+}
 .growth-summary-label, .growth-period > span { color: var(--growth-faint); font-family: var(--mono); font-size: 10px; letter-spacing: .11em; text-transform: uppercase; }
 .growth-summary-label { display: flex; z-index: 1; min-width: 0; align-items: center; justify-content: space-between; gap: 10px; }
 .growth-summary strong { color: var(--growth-text); font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.growth-delta { display: inline-flex; min-width: 0; align-items: baseline; gap: 5px; white-space: nowrap; }
+.growth-delta strong { color: var(--growth-accent); font-size: 11px; font-weight: 700; letter-spacing: .03em; }
+.growth-delta small { color: var(--growth-faint); font-size: 9px; letter-spacing: .08em; }
+.growth-delta.is-flat strong { color: var(--growth-muted); }
 .growth-total > strong {
-  display: grid; z-index: 1; align-items: center; grid-template-columns: minmax(60px, 1fr) 18px minmax(78px, 1.15fr);
+  display: grid; z-index: 1; align-items: center; grid-template-columns: minmax(60px, 1fr) 18px minmax(60px, 1fr);
   column-gap: 3px; font-size: clamp(21px, 1.8vw, 30px); line-height: 1;
 }
 .growth-total > strong > span { min-width: 0; text-align: right; }
@@ -357,6 +363,8 @@
 .growth-rate i { font-size: 12px; font-style: normal; text-align: center; }
 .growth-rate span { min-width: 0; text-align: right; }
 .growth-rate.is-flat { color: var(--growth-muted) !important; }
+.growth-period { justify-items: center; text-align: center; }
+.growth-period > span, .growth-period > strong { display: flex; align-items: center; }
 .growth-period strong { color: var(--growth-text); font-size: 12px; font-weight: 500; letter-spacing: .04em; text-transform: uppercase; white-space: nowrap; }
 .growth-poster {
   --growth-bg: #000;
@@ -511,7 +519,7 @@
   .growth-poster-title h2 { margin-top: 14px; font-size: 32px; }
   .growth-poster-title p { font-size: 13px; line-height: 1.5; }
   .growth-summary { width: 100%; min-height: 94px; }
-  .growth-summary > div { padding: 15px 14px; }
+  .growth-summary > div { padding: 0 14px; }
   .growth-summary-label, .growth-period > span { font-size: 10px; }
   .growth-total > strong { font-size: 20px; }
   .growth-rate { font-size: 11px; }
@@ -521,4 +529,15 @@
   .growth-poster-footer { align-items: flex-start; flex-direction: column; gap: 18px; }
   .growth-legend { align-items: flex-start; flex-direction: column; gap: 10px; }
   .growth-source { text-align: left; }
+}
+
+@media (max-width: 400px) {
+  .growth-summary { grid-template-columns: minmax(0, 1fr) 84px; }
+  .growth-summary > div { padding-inline: 10px; }
+  .growth-summary-label { gap: 5px; }
+  .growth-delta { gap: 4px; }
+  .growth-delta strong { font-size: 10px; }
+  .growth-delta small { font-size: 9px; }
+  .growth-rate { width: 62px; flex-basis: 62px; grid-template-columns: 14px 1fr; font-size: 10px; }
+  .growth-period strong { font-size: 11px; }
 }

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -901,6 +901,11 @@ function renderGrowth({ updateUrl = true } = {}) {
   const period = inclusiveDayCount(from, to);
   document.querySelector("#growth-start-total").textContent = number.format(start.total);
   document.querySelector("#growth-end-total").textContent = number.format(end.total);
+  const growthDelta = document.querySelector("#growth-delta");
+  growthDelta.querySelector("strong").textContent = `${change > 0 ? "+" : ""}${number.format(change)}`;
+  growthDelta.classList.toggle("is-flat", change === 0);
+  const absoluteChange = Math.abs(change);
+  growthDelta.setAttribute("aria-label", `${number.format(absoluteChange)} plugin${absoluteChange === 1 ? "" : "s"} ${trendWord} over the selected period`);
   document.querySelector("#growth-trend-arrow").textContent = trendArrow;
   document.querySelector("#growth-rate-value").textContent = rateText;
   const growthRate = document.querySelector("#growth-rate");

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -153,12 +153,28 @@ function nodeRadius(node) {
   return 2.8 + Math.min(9, Math.log10((node.stars || 0) + 1) * 1.8 + Math.sqrt(node.influence || 0) * .12);
 }
 
+function drawCanvasLabel({ text, x, y, font, color, opacity, haloColor, haloWidth }) {
+  context.save();
+  context.font = font;
+  context.lineJoin = "round";
+  context.strokeStyle = haloColor;
+  context.lineWidth = haloWidth;
+  context.globalAlpha = Math.min(1, opacity + .28);
+  context.strokeText(text, x, y);
+  context.fillStyle = color;
+  context.globalAlpha = opacity;
+  context.fillText(text, x, y);
+  context.restore();
+}
+
 function drawGraph() {
   if (!explorer || !canvasSize.width || graphView.hidden) return;
   context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
   context.clearRect(0, 0, canvasSize.width, canvasSize.height);
   const lightTheme = document.documentElement.dataset.theme === "light";
+  const labelHaloColor = lightTheme ? "#f8f8f6" : "#000";
   const occupiedLabels = [];
+  const clusterLabels = [];
 
   context.lineWidth = Math.max(.7, viewport.scale * .75);
   for (const edge of explorer.edges) {
@@ -197,9 +213,18 @@ function drawGraph() {
     context.arc(hub.x, hub.y, 5.5 + Math.sqrt(members.length), 0, Math.PI * 2);
     context.fill();
     context.shadowBlur = 0;
-    context.font = "700 11px Inter, sans-serif";
-    context.fillStyle = lightTheme ? "#19191b" : "#efeff0";
-    context.fillText(cluster.label, hub.x + 13, hub.y + 4);
+    const font = "700 11px Inter, sans-serif";
+    context.font = font;
+    clusterLabels.push({
+      text: cluster.label,
+      x: hub.x + 13,
+      y: hub.y + 4,
+      font,
+      color: lightTheme ? "#19191b" : "#efeff0",
+      opacity: .95,
+      haloColor: labelHaloColor,
+      haloWidth: 4,
+    });
     occupiedLabels.push({ x: hub.x + 10, y: hub.y - 9, width: context.measureText(cluster.label).width + 8, height: 16 });
   }
 
@@ -220,6 +245,8 @@ function drawGraph() {
     context.shadowBlur = 0;
   }
 
+  for (const label of clusterLabels) drawCanvasLabel(label);
+
   const lastRankedIndex = rankedNodes.length - 1;
   const primaryLabelInfluence = rankedNodes[Math.min(24, lastRankedIndex)]?.influence ?? Number.POSITIVE_INFINITY;
   const zoomedLabelInfluence = rankedNodes[Math.min(80, lastRankedIndex)]?.influence ?? primaryLabelInfluence;
@@ -237,9 +264,16 @@ function drawGraph() {
     const overlaps = occupiedLabels.some((item) => box.x < item.x + item.width && box.x + box.width > item.x && box.y < item.y + item.height && box.y + box.height > item.y);
     if (overlaps && !focus) continue;
     occupiedLabels.push(box);
-    context.globalAlpha = focus ? 1 : lightTheme ? .72 : .52;
-    context.fillStyle = lightTheme ? "#19191b" : "#c5c5c8";
-    context.fillText(node.name, position.x + radius + 5, position.y + 4);
+    drawCanvasLabel({
+      text: node.name,
+      x: position.x + radius + 5,
+      y: position.y + 4,
+      font: context.font,
+      color: lightTheme ? "#19191b" : "#c5c5c8",
+      opacity: focus ? 1 : lightTheme ? .72 : .52,
+      haloColor: labelHaloColor,
+      haloWidth: focus ? 4 : 3,
+    });
   }
   context.globalAlpha = 1;
 }

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -270,7 +270,7 @@ function drawGraph() {
       y: position.y + 4,
       font: context.font,
       color: lightTheme ? "#19191b" : "#c5c5c8",
-      opacity: focus ? 1 : lightTheme ? .72 : .52,
+      opacity: focus ? 1 : lightTheme ? .72 : .65,
       haloColor: labelHaloColor,
       haloWidth: focus ? 4 : 3,
     });

--- a/site/explore.html
+++ b/site/explore.html
@@ -239,6 +239,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260828-24"></script>
+    <script type="module" src="assets/js/explore.js?v=20260828-25"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -239,6 +239,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260828-23"></script>
+    <script type="module" src="assets/js/explore.js?v=20260828-24"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -8,7 +8,7 @@
     <title>Explore Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
     <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
-    <link rel="stylesheet" href="assets/css/explore.css?v=20260828-24">
+    <link rel="stylesheet" href="assets/css/explore.css?v=20260828-27">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page explore-page">
@@ -168,7 +168,7 @@
             <div class="growth-summary" aria-live="polite">
               <div class="growth-total">
                 <div class="growth-summary-label">
-                  <span>Total Growth</span>
+                  <span id="growth-delta" class="growth-delta" aria-label="Net plugin growth over the selected period"><strong>0</strong><small>plugins</small></span>
                   <strong id="growth-rate" class="growth-rate" aria-label="Percentage growth over the selected period"><i id="growth-trend-arrow" aria-hidden="true">→</i><span id="growth-rate-value">0%</span></strong>
                 </div>
                 <strong><span id="growth-start-total">0</span><i aria-hidden="true">→</i><em id="growth-end-total">0</em></strong>
@@ -239,6 +239,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260828-25"></script>
+    <script type="module" src="assets/js/explore.js?v=20260828-26"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1174,7 +1174,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
   assert.equal(keys[0], "20260827-01");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-23");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-24");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1174,7 +1174,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
   assert.equal(keys[0], "20260827-01");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-24");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-25");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1174,7 +1174,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
   assert.equal(keys[0], "20260827-01");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-25");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260828-26");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -232,8 +232,9 @@ test("explore page exposes graph and date-filtered growth views", () => {
 test("growth view preserves the source graphic's presentation hierarchy", () => {
   assert.match(page, /class="growth-poster"/);
   assert.match(page, /Community Registry[\s\S]*<h2>community plugins<\/h2>/);
-  assert.match(page, /class="growth-summary"[\s\S]*Total Growth[\s\S]*id="growth-start-total"[\s\S]*id="growth-end-total"[\s\S]*Period/);
+  assert.match(page, /class="growth-summary"[\s\S]*id="growth-delta"[^>]+class="growth-delta"[\s\S]*plugins[\s\S]*id="growth-start-total"[\s\S]*id="growth-end-total"[\s\S]*Period/);
   assert.match(page, /id="growth-rate"[\s\S]*id="growth-trend-arrow"[\s\S]*id="growth-rate-value"/);
+  assert.match(script, /growthDelta\.querySelector\("strong"\)\.textContent = `\$\{change > 0 \? "\+" : ""\}\$\{number\.format\(change\)\}`[\s\S]*plugin\$\{absoluteChange === 1 \? "" : "s"\} \$\{trendWord\} over the selected period/);
   assert.match(page, /class="growth-plot-meta"[\s\S]*Plugin Count[\s\S]*class="growth-plot-frame"[\s\S]*viewBox="0 0 1728 620"/);
   assert.match(page, /id="growth-chart"[^>]+aria-label="Community plugin growth"[^>]+aria-describedby="growth-chart-description"/);
   assert.doesNotMatch(page, /<title id="growth-chart-title">/);
@@ -255,10 +256,15 @@ test("explore UI follows marketplace geometry, readable type, and complete theme
   assert.match(styles, /\.date-input-shell svg[\s\S]*stroke:\s*var\(--muted\)/);
   assert.match(styles, /\[data-theme="light"\] \.growth-poster[\s\S]*--growth-bg:\s*#f8f8f6[\s\S]*--growth-accent:\s*#c6371c/);
   assert.match(styles, /\[data-chart-line\]\s*\{\s*stroke:\s*var\(--growth-accent\)/);
-  assert.match(styles, /\.growth-total > strong[\s\S]*grid-template-columns:\s*minmax\(60px, 1fr\) 18px minmax\(78px, 1\.15fr\)/);
+  assert.match(styles, /\.growth-summary > div\s*\{[^}]*padding:\s*0 16px[^}]*grid-template-rows:\s*49% 51%[^}]*gap:\s*0/);
+  assert.match(styles, /\.growth-total > strong[\s\S]*grid-template-columns:\s*minmax\(60px, 1fr\) 18px minmax\(60px, 1fr\)/);
+  assert.match(styles, /\.growth-period\s*\{[^}]*justify-items:\s*center;[^}]*text-align:\s*center/);
+  assert.match(styles, /\.growth-period > span, \.growth-period > strong\s*\{[^}]*display:\s*flex;[^}]*align-items:\s*center/);
   assert.match(page, /id="growth-rate" class="growth-rate"/);
   assert.match(styles, /\.growth-rate[\s\S]*width:\s*68px[\s\S]*flex:\s*0 0 68px[\s\S]*grid-template-columns:\s*16px 1fr[\s\S]*font-size:\s*11px/);
   assert.match(styles, /\.growth-rate i\s*\{\s*font-size:\s*12px/);
+  assert.match(styles, /\.growth-delta\s*\{[\s\S]*gap:\s*5px[\s\S]*white-space:\s*nowrap[\s\S]*\.growth-delta strong\s*\{[^}]*color:\s*var\(--growth-accent\)[^}]*font-size:\s*11px/);
+  assert.match(styles, /@media \(max-width:\s*400px\)[\s\S]*\.growth-summary\s*\{\s*grid-template-columns:\s*minmax\(0, 1fr\) 84px[\s\S]*\.growth-rate\s*\{[^}]*width:\s*62px/);
   assert.match(styles, /\.explore-freshness[\s\S]*font-size:\s*10px[\s\S]*letter-spacing:\s*\.09em/);
   assert.match(styles, /\.explore-freshness time, \.explore-freshness strong[\s\S]*color:\s*var\(--accent\)/);
   assert.match(styles, /\.growth-source strong[\s\S]*color:\s*var\(--growth-accent\)/);

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -291,6 +291,8 @@ test("all semantic communities remain available in a compact labeled rail", () =
   assert.match(script, /rankedNodes\[Math\.min\(24, lastRankedIndex\)\]\?\.influence/);
   assert.match(script, /rankedNodes\[Math\.min\(80, lastRankedIndex\)\]\?\.influence/);
   assert.doesNotMatch(script, /rankedNodes\[(?:24|80)\]\.influence/);
+  assert.match(script, /function drawCanvasLabel[\s\S]*context\.strokeText\(text, x, y\)[\s\S]*context\.fillText\(text, x, y\)/);
+  assert.match(script, /const clusterLabels = \[\][\s\S]*clusterLabels\.push\([\s\S]*for \(const node of explorer\.nodes\)[\s\S]*for \(const label of clusterLabels\) drawCanvasLabel\(label\)/);
   assert.doesNotMatch(styles, /\.anchor-list|\.anchor-row|\.anchor-dot/);
   assert.match(page, /id="graph-method" class="status-method">Local TF-IDF similarity<\/span>/);
   assert.match(script, /document\.querySelector\("#graph-method"\)\.setAttribute\("aria-label", explorer\.method/);

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -293,6 +293,7 @@ test("all semantic communities remain available in a compact labeled rail", () =
   assert.doesNotMatch(script, /rankedNodes\[(?:24|80)\]\.influence/);
   assert.match(script, /function drawCanvasLabel[\s\S]*context\.strokeText\(text, x, y\)[\s\S]*context\.fillText\(text, x, y\)/);
   assert.match(script, /const clusterLabels = \[\][\s\S]*clusterLabels\.push\([\s\S]*for \(const node of explorer\.nodes\)[\s\S]*for \(const label of clusterLabels\) drawCanvasLabel\(label\)/);
+  assert.match(script, /opacity:\s*focus \? 1 : lightTheme \? \.72 : \.65/);
   assert.doesNotMatch(styles, /\.anchor-list|\.anchor-row|\.anchor-dot/);
   assert.match(page, /id="graph-method" class="status-method">Local TF-IDF similarity<\/span>/);
   assert.match(script, /document\.querySelector\("#graph-method"\)\.setAttribute\("aria-label", explorer\.method/);


### PR DESCRIPTION
## Summary
- Improve graph-label layering with theme-aware halos.
- Raise dimmed-label contrast in the dark theme.
- Show the absolute plugin-growth delta with stable, centered summary metrics.

## Verification
- npm test: 239/239 passed.
- Runtime review at 320, 375, 760, and 1440 px.
- Dark and light themes verified.
- git diff --check passed.