### PR TITLE
Allow verified updates of legacy listings

### DIFF
--- a/scripts/plugin-update.mjs
+++ b/scripts/plugin-update.mjs
@@ -68,12 +68,15 @@ function mappedSubjectCode(code) {
 }
 
 export function sourceForPluginUpdate(registry, request) {
+  let source;
   try {
-    return resolveConfiguredSource(registry, request);
+    source = resolveConfiguredSource(registry, request);
   } catch (error) {
     if (!(error instanceof VerificationSubjectError)) throw error;
     throw new PluginUpdateError(mappedSubjectCode(error.code), error.message, error.context);
   }
+  assertPluginUpdateListingArchivable(source);
+  return source;
 }
 
 function sortedPluginIds(value) {
@@ -125,16 +128,22 @@ function sourceEvidenceValid(source) {
   } catch {
     return false;
   }
-  const baseline = parseStoredSecurityBaselineRecord(source?.automatedSecurityBaseline, {
-    expectedRepository,
-    allowedRepositories,
-    allowLegacyRepositoryFallback: !migrated,
-    expectedCommit: source?.listingValidatedCommit,
-    pluginIds: sourcePluginIds(source),
-  }) || (!migrated ? legacyBaselineValid(source) : null);
-  if (!baseline) return false;
+  // A missing baseline denotes a legacy unverified snapshot. Once the field is
+  // present, it is trust evidence and must remain exact and fully parseable.
+  const hasBaseline = Object.hasOwn(source || {}, "automatedSecurityBaseline");
+  const baseline = hasBaseline
+    ? parseStoredSecurityBaselineRecord(source.automatedSecurityBaseline, {
+      expectedRepository,
+      allowedRepositories,
+      allowLegacyRepositoryFallback: !migrated,
+      expectedCommit: source?.listingValidatedCommit,
+      pluginIds: sourcePluginIds(source),
+    }) || (!migrated ? legacyBaselineValid(source) : null)
+    : null;
+  if (hasBaseline && !baseline) return false;
   const hasReview = Object.hasOwn(source || {}, "maintainerVerificationReview");
   const hasRevocation = Object.hasOwn(source || {}, "maintainerVerificationRevocation");
+  if ((hasReview || hasRevocation) && !baseline) return false;
   if (hasRevocation && !hasReview) return false;
   if (hasReview && !parseMaintainerVerificationReview(source.maintainerVerificationReview, baseline)) return false;
   if (
@@ -161,6 +170,31 @@ function sourceEvidenceValid(source) {
       allowLegacyRepositoryFallback: !migrated,
       pluginIds: sourcePluginIds(source),
     });
+}
+
+export function assertPluginUpdateListingArchivable(source) {
+  if (
+    source?.type !== "plugin-source"
+    || !sourcePluginIds(source).length
+    || !sourceEvidenceValid(source)
+  ) {
+    throw new PluginUpdateError(
+      "update-listing-invalid",
+      "The current listing evidence cannot be archived safely",
+    );
+  }
+  if (
+    !fullCommitPattern.test(source.listingValidatedCommit || "")
+    || !Number.isFinite(Date.parse(source.listingValidatedAt || ""))
+    || typeof source.listingValidatedBranch !== "string"
+    || !source.listingValidatedBranch
+  ) {
+    throw new PluginUpdateError(
+      "update-listing-invalid",
+      "The current listing provenance cannot be archived safely",
+    );
+  }
+  return source;
 }
 
 export function assertPluginUpdateInspection(request, source, inspection, {
@@ -212,12 +246,7 @@ export function resolvePluginUpdate(registry, request, inspection, options = {})
 }
 
 export function listingValidationHistoryEntry(source, supersededAt) {
-  if (!sourceEvidenceValid(source)) {
-    throw new PluginUpdateError(
-      "update-listing-invalid",
-      "The current listing evidence cannot be archived safely",
-    );
-  }
+  assertPluginUpdateListingArchivable(source);
   const expectedRepository = githubRepositoryKey(source.repo);
   const allowedRepositories = repositoryEvidenceKeys(source);
   if (Object.hasOwn(source || {}, "maintainerVerificationRevocation")) {

--- a/test/plugin-update.test.js
+++ b/test/plugin-update.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import { inspectListedPluginSource } from "../scripts/build-catalog.mjs";
 import {
   assertPluginUpdateInspection,
+  assertPluginUpdateListingArchivable,
   buildPluginUpdateValidationReport,
   listingValidationHistoryEntry,
   parsePluginUpdateRequest,
@@ -67,6 +68,27 @@ function storedBaseline(commit = oldCommit, overrides = {}) {
   };
 }
 
+function maintainerReview(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    repository: "example/plugin",
+    pluginIds: ["example.plugin"],
+    commit: oldCommit,
+    baselineVersion: securityBaselineVersion,
+    enforcementMode: securityBaselineEnforcementMode,
+    baselineCheckedAt: oldCheckedAt,
+    baselineOutcome: "review-required",
+    findings: [],
+    capabilities: ["privilege"],
+    reviewedBaselineCheckedAt: "2026-08-18T08:00:00.000Z",
+    requestEventId: 44001,
+    requestedAt: "2026-08-18T09:00:00.000Z",
+    reviewedAt: "2026-08-18T11:00:00.000Z",
+    reviewer: "hancore",
+    ...overrides,
+  };
+}
+
 function listedSource(overrides = {}) {
   return {
     repo: "https://github.com/example/plugin",
@@ -82,6 +104,12 @@ function listedSource(overrides = {}) {
     },
     ...overrides,
   };
+}
+
+function baselineLessListedSource(overrides = {}) {
+  const source = listedSource(overrides);
+  delete source.automatedSecurityBaseline;
+  return source;
 }
 
 function updateInspection(overrides = {}) {
@@ -156,12 +184,94 @@ test("plugin updates bind repository HEAD and the complete configured plugin set
   );
   assert.throws(
     () => resolvePluginUpdate(
-      { sources: [listedSource({ listingValidatedCommit: updateCommit })] },
+      { sources: [listedSource({
+        listingValidatedCommit: updateCommit,
+        automatedSecurityBaseline: storedBaseline(updateCommit),
+      })] },
       request,
       updateInspection(),
     ),
     (error) => error.code === "update-already-current",
   );
+});
+
+test("baseline-less legacy listings validate and promote without invented history evidence", () => {
+  const source = baselineLessListedSource();
+  const request = parsePluginUpdateRequest(requestBody());
+  const subject = resolvePluginUpdate({ sources: [source] }, request, updateInspection());
+  assert.equal(subject.source, source);
+  assert.equal(sourceVerification(source).status, "unverified");
+
+  const historyEntry = listingValidationHistoryEntry(source, promotedAt);
+  assert.deepEqual(historyEntry, {
+    commit: oldCommit,
+    validatedAt: oldCheckedAt,
+    branch: "main",
+    supersededAt: promotedAt,
+  });
+  assert.equal(Object.hasOwn(historyEntry, "automatedSecurityBaseline"), false);
+
+  const nextSource = promotePluginUpdateSource(source, updateInspection(), {
+    automatedSecurityBaseline: storedBaseline(updateCommit),
+    promotedAt,
+  });
+  assert.deepEqual(nextSource.listingValidationHistory, [historyEntry]);
+  assert.equal(nextSource.automatedSecurityBaseline.commit, updateCommit);
+  assert.equal(sourceVerification(nextSource).status, "verified");
+  assert.equal(Object.hasOwn(source, "automatedSecurityBaseline"), false);
+});
+
+test("legacy archival rejects malformed or orphaned trust evidence", () => {
+  const request = parsePluginUpdateRequest(requestBody());
+  const malformedSources = [
+    listedSource({ automatedSecurityBaseline: null }),
+    listedSource({ automatedSecurityBaseline: {} }),
+    listedSource({
+      automatedSecurityBaseline: { ...storedBaseline(), commit: updateCommit },
+    }),
+    baselineLessListedSource({ maintainerVerificationReview: maintainerReview() }),
+    baselineLessListedSource({ maintainerVerificationRevocation: {} }),
+    baselineLessListedSource({ maintainerVerificationReviewHistory: [{}] }),
+  ];
+  for (const source of malformedSources) {
+    assert.throws(
+      () => resolvePluginUpdate({ sources: [source] }, request, updateInspection()),
+      (error) => error.code === "update-listing-invalid",
+    );
+    assert.throws(
+      () => listingValidationHistoryEntry(source, promotedAt),
+      (error) => error.code === "update-listing-invalid",
+    );
+  }
+});
+
+test("legacy archival requires complete existing listing provenance before validation", () => {
+  for (const source of [
+    baselineLessListedSource({ listingValidatedCommit: "abc" }),
+    baselineLessListedSource({ listingValidatedAt: "not-a-date" }),
+    baselineLessListedSource({ listingValidatedBranch: "" }),
+    baselineLessListedSource({ plugins: {} }),
+  ]) {
+    assert.throws(
+      () => assertPluginUpdateListingArchivable(source),
+      (error) => error.code === "update-listing-invalid",
+    );
+  }
+});
+
+test("current baseline-less legacy sources are archivable as unverified provenance", async () => {
+  const registry = JSON.parse(await readFile(new URL("../registry.json", import.meta.url), "utf8"));
+  const sources = registry.sources.filter((source) => (
+    source.type === "plugin-source"
+    && !Object.hasOwn(source, "automatedSecurityBaseline")
+  ));
+  for (const source of sources) {
+    assert.doesNotThrow(() => assertPluginUpdateListingArchivable(source), source.repo);
+    const entry = listingValidationHistoryEntry(source, promotedAt);
+    assert.equal(Object.hasOwn(entry, "automatedSecurityBaseline"), false, source.repo);
+    assert.equal(Object.hasOwn(entry, "maintainerVerificationReview"), false, source.repo);
+    assert.equal(Object.hasOwn(entry, "maintainerVerificationRevocation"), false, source.repo);
+  }
 });
 
 test("verified update promotion preserves prior evidence and atomically replaces the snapshot", () => {
@@ -192,23 +302,7 @@ test("verified update promotion preserves prior evidence and atomically replaces
 });
 
 test("plugin update history preserves revoked review evidence and clears it from the active snapshot", () => {
-  const review = {
-    schemaVersion: 1,
-    repository: "example/plugin",
-    pluginIds: ["example.plugin"],
-    commit: oldCommit,
-    baselineVersion: securityBaselineVersion,
-    enforcementMode: securityBaselineEnforcementMode,
-    baselineCheckedAt: oldCheckedAt,
-    baselineOutcome: "review-required",
-    findings: [],
-    capabilities: ["privilege"],
-    reviewedBaselineCheckedAt: "2026-08-18T08:00:00.000Z",
-    requestEventId: 44001,
-    requestedAt: "2026-08-18T09:00:00.000Z",
-    reviewedAt: "2026-08-18T11:00:00.000Z",
-    reviewer: "hancore",
-  };
+  const review = maintainerReview();
   const revocation = {
     schemaVersion: 1,
     repository: review.repository,
@@ -421,6 +515,11 @@ test("plugin update workflows preserve read-only analysis and atomic publication
   assert.doesNotMatch(validation, /\n  report-failure:\n/);
   assert.match(validation, /permissions:\s+contents: read\s+issues: read/);
   assert.match(validation, /npm ci[\s\S]*validate-plugin-update\.mjs[\s\S]*security-baseline\.mjs/);
+  assert.ok(
+    validationScript.indexOf("const source = sourceForPluginUpdate(registry, request);")
+      < validationScript.indexOf("inspection = await inspectListedPluginSource(source);"),
+    "legacy listing archival must be prechecked before upstream inspection",
+  );
   assert.match(validation, /actions\/upload-artifact@[a-f0-9]{40}/);
   assert.match(validation, /actions\/download-artifact@[a-f0-9]{40}/);
   assert.equal((validation.match(/GH_REPO: \$\{\{ github\.repository \}\}/g) || []).length, 1);


### PR DESCRIPTION
## Summary

- archive baseline-less legacy listing provenance as historical unverified state during a verified update
- reject malformed baselines, orphaned review or revocation evidence, and incomplete listing provenance
- preflight listing archivability during update validation, before maintainer approval
- keep new active snapshots bound to a fresh, exact, valid automated security baseline

## Security properties

- no historical baseline is invented for a legacy listing
- present but malformed trust evidence remains fatal
- review or revocation evidence without a valid baseline remains fatal
- validation and publication use the same archival guard

## Tests

- `npm ci`
- `node --test test/plugin-update.test.js` — 13/13 passed
- `npm test` — 284/284 passed
- syntax and whitespace checks
