### PR TITLE
Fix catalog refresh batch boundary test

### DIFF
--- a/test/catalog-refresh-graphql.test.js
+++ b/test/catalog-refresh-graphql.test.js
@@ -8,6 +8,8 @@ import {
   buildCatalog,
   canReuseFullRefreshSource,
   catalogRefreshGraphqlBatchSize,
+  catalogRefreshGraphqlBudgetReserve,
+  catalogRefreshGraphqlPointsPerBatchReserve,
   catalogRefreshIdentityQuery,
   catalogRefreshRestBudgetReserve,
   catalogSourceFingerprint,
@@ -291,6 +293,84 @@ test("GraphQL identity batches accept exact data and isolate only explicit repos
       restRateLimitRequests: 0,
       restTreeRequests: 0,
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("GraphQL identity acquisition crosses its batch boundary only with sufficient live budget", async () => {
+  const sources = Array.from(
+    { length: catalogRefreshGraphqlBatchSize + 1 },
+    (_, index) => source({
+      repo: `https://github.com/example/plugin-${index}`,
+      plugins: { [`example.plugin-${index}`]: {} },
+    }),
+  );
+  const expectedBatchCount = Math.ceil(sources.length / catalogRefreshGraphqlBatchSize);
+  const preflightRequired =
+    expectedBatchCount * catalogRefreshGraphqlPointsPerBatchReserve
+    + catalogRefreshGraphqlBudgetReserve;
+  const originalFetch = globalThis.fetch;
+  let preflightRemaining = preflightRequired - 1;
+  let identityBudgetAdjustment = 0;
+  const identityBatchSizes = [];
+  globalThis.fetch = async (_input, init = {}) => {
+    const request = JSON.parse(init.body);
+    if (request.query.includes("CatalogRefreshBudget")) {
+      return jsonResponse({ data: { rateLimit: graphqlRate(preflightRemaining) } });
+    }
+    const batchSize = Object.keys(request.variables)
+      .filter((key) => key.startsWith("owner"))
+      .length;
+    identityBatchSizes.push(batchSize);
+    const remainingBatchCount = expectedBatchCount - identityBatchSizes.length;
+    const data = {
+      rateLimit: graphqlRate(
+        remainingBatchCount * catalogRefreshGraphqlPointsPerBatchReserve
+          + catalogRefreshGraphqlBudgetReserve
+          + identityBudgetAdjustment,
+      ),
+    };
+    for (let index = 0; index < batchSize; index += 1) {
+      data[`r${index}`] = graphqlRepository({
+        nameWithOwner: `${request.variables[`owner${index}`]}/${request.variables[`name${index}`]}`,
+      });
+    }
+    return jsonResponse({ data });
+  };
+
+  try {
+    await assert.rejects(
+      resolveFullRefreshIdentities(sources),
+      (error) => error instanceof CatalogBuildError
+        && error.code === "api-budget-insufficient"
+        && error.message.includes(
+          `remaining ${preflightRequired - 1}, required ${preflightRequired}`,
+        ),
+    );
+    assert.deepEqual(identityBatchSizes, []);
+
+    preflightRemaining = preflightRequired;
+    identityBudgetAdjustment = -1;
+    const remainingBatchRequired =
+      catalogRefreshGraphqlPointsPerBatchReserve
+      + catalogRefreshGraphqlBudgetReserve;
+    await assert.rejects(
+      resolveFullRefreshIdentities(sources),
+      (error) => error instanceof CatalogBuildError
+        && error.code === "api-budget-insufficient"
+        && error.message.includes(
+          `remaining ${remainingBatchRequired - 1}, required ${remainingBatchRequired}`,
+        ),
+    );
+    assert.deepEqual(identityBatchSizes, [catalogRefreshGraphqlBatchSize]);
+
+    identityBatchSizes.length = 0;
+    identityBudgetAdjustment = 0;
+    const result = await resolveFullRefreshIdentities(sources);
+    assert.equal(result.size, catalogRefreshGraphqlBatchSize + 1);
+    assert.equal(result.get("example/plugin-50").context.commitSha, commit);
+    assert.deepEqual(identityBatchSizes, [catalogRefreshGraphqlBatchSize, 1]);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -607,5 +687,4 @@ test("the current registry fits a complete policy revalidation inside the reserv
   const sourceCount = (registry.sources || []).length + (registry.builtInSources || []).length;
   assert.ok(sourceCount > 1_600);
   assert.ok(sourceCount + catalogRefreshRestBudgetReserve < 5_000);
-  assert.equal(Math.ceil(sourceCount / catalogRefreshGraphqlBatchSize), 34);
 });


### PR DESCRIPTION
## Summary

- remove the inventory-pinned GraphQL batch count from the REST revalidation capacity test
- cover the configured 50-to-51 source batch boundary with live-budget fixtures
- keep insufficient preflight and between-batch budgets fail-closed

## Why

Approval builds add the candidate source before running the repository tests. At 1,700 combined community and built-in sources, the next listing correctly requires 35 GraphQL batches instead of 34, but the test asserted the old inventory snapshot exactly and blocked publication.

The runtime already calculates the batch count dynamically and checks the actual GraphQL budget before acquisition and after every batch. This change does not alter runtime behavior or weaken those checks.

## Verification

- `node --test test/catalog-refresh-graphql.test.js` — 13/13 passed
- `npm test` — 285/285 passed
- `node --check test/catalog-refresh-graphql.test.js`
- `git diff --check origin/main..HEAD`
- independent adversarial review — no findings
