### PR TITLE
Prepare engagement for plugins.omarchy.org

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,14 +25,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-01";
+} from "./shared.js?v=20260830-02";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260830-01";
+} from "./engagement.js?v=20260830-02";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -59,7 +59,7 @@ import {
   searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260830-01";
+} from "./search.js?v=20260830-02";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-01";
+} from "./shared.js?v=20260830-02";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/engagement.js
+++ b/site/assets/js/engagement.js
@@ -1,4 +1,5 @@
 const productionSiteHosts = new Set([
+  "plugins.omarchy.org",
   "omarchyplugins.com",
   "www.omarchyplugins.com",
 ]);

--- a/site/assets/js/explore-search.js
+++ b/site/assets/js/explore-search.js
@@ -2,7 +2,7 @@ import {
   matchesDirectSearch,
   matchesDraftSearchTerm,
   parseSearchDraft,
-} from "./search.js?v=20260830-01";
+} from "./search.js?v=20260830-02";
 
 export function repositoryPublisher(repo) {
   try {

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -1,5 +1,5 @@
-import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260830-01";
-import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260830-01";
+import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260830-02";
+import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260830-02";
 import { inclusiveDayCount, inclusiveRangeStart } from "./growth-range.js?v=20260828-18";
 
 const number = new Intl.NumberFormat("en-US");

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-01";
+} from "./shared.js?v=20260830-02";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260830-01";
+} from "./engagement.js?v=20260830-02";
 
 function safeGitHubWebUrl(value) {
   try {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-01";
+} from "./shared.js?v=20260830-02";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260830-01"></script>
+    <script type="module" src="assets/js/develop.js?v=20260830-02"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -239,6 +239,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260830-01"></script>
+    <script type="module" src="assets/js/explore.js?v=20260830-02"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -186,6 +186,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260830-01"></script>
+    <script type="module" src="assets/js/app.js?v=20260830-02"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -37,6 +37,6 @@
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260830-01"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260830-02"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260830-01"></script>
+    <script type="module" src="assets/js/publish.js?v=20260830-02"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1183,9 +1183,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260830-01");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260830-01");
-  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260830-01");
+  assert.equal(keys[0], "20260830-02");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260830-02");
+  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260830-02");
   assert.equal(files.exploreJs.match(/growth-range\.js\?v=([^"']+)/)?.[1], "20260828-18");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);

--- a/test/engagement.test.js
+++ b/test/engagement.test.js
@@ -84,7 +84,8 @@ function fakeRateLimiter(success = true) {
   };
 }
 
-const productionLocation = { hostname: "omarchyplugins.com" };
+const productionLocation = { hostname: "plugins.omarchy.org" };
+const legacyProductionLocation = { hostname: "omarchyplugins.com" };
 const localLocation = { hostname: "127.0.0.1" };
 const testMinuteLimitVars = {
   VIEW_MINUTE_EVENT_LIMIT: "2",
@@ -92,10 +93,22 @@ const testMinuteLimitVars = {
   HEART_MINUTE_EVENT_LIMIT: "2",
 };
 
-test("engagement API routing is explicit and disabled on unrecognized hosts", () => {
+test("engagement API routing supports canonical and legacy production hosts exactly", () => {
   assert.equal(engagementApiBaseUrl(productionLocation), "https://api.omarchyplugins.com/v1");
+  assert.equal(engagementApiBaseUrl(legacyProductionLocation), "https://api.omarchyplugins.com/v1");
+  assert.equal(
+    engagementApiBaseUrl({ hostname: "www.omarchyplugins.com" }),
+    "https://api.omarchyplugins.com/v1",
+  );
   assert.equal(engagementApiBaseUrl(localLocation), "http://127.0.0.1:8787/v1");
-  assert.equal(engagementApiBaseUrl({ hostname: "preview.example" }), "");
+  for (const hostname of [
+    "preview.example",
+    "plugins.omarchy.org.evil.example",
+    "www.plugins.omarchy.org",
+    "plugins.omarchy.org.",
+  ]) {
+    assert.equal(engagementApiBaseUrl({ hostname }), "");
+  }
 });
 
 test("engagement counts and summaries stay compact, accessible, and command-aware", () => {
@@ -464,6 +477,41 @@ test("Worker exposes aggregate stats with restricted CORS and no credentials", a
     plugins: { "example.plugin": { views: 8, copies: 3, hearts: 5 } },
   });
   assert.equal(database.calls[0].operation, "all");
+});
+
+test("Worker permits canonical and legacy origins exactly", async () => {
+  const env = { ENGAGEMENT_DB: fakeDatabase() };
+  for (const origin of [
+    "https://plugins.omarchy.org",
+    "https://omarchyplugins.com",
+    "https://www.omarchyplugins.com",
+  ]) {
+    const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+      method: "OPTIONS",
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+      },
+    }), env);
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), origin);
+  }
+  for (const origin of [
+    "http://plugins.omarchy.org",
+    "https://plugins.omarchy.org.evil.example",
+    "https://www.plugins.omarchy.org",
+    "https://plugins.omarchy.org:444",
+  ]) {
+    const response = await handleRequest(new Request("https://api.omarchyplugins.com/v1/events", {
+      method: "OPTIONS",
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+      },
+    }), env);
+    assert.equal(response.status, 403);
+    assert.equal(response.headers.has("Access-Control-Allow-Origin"), false);
+  }
 });
 
 test("Worker rejects streamed oversized event bodies without buffering or catalog access", async () => {
@@ -840,11 +888,19 @@ test("Worker records only known catalog plugins from allowed origins", async () 
   assert.match(rateLimiter.keys[0], /^events:/);
   assert.match(targetRateLimiter.keys[0], /^target:/);
 
+  const canonical = await handleRequest(
+    request("example.plugin", "https://plugins.omarchy.org", "copy"),
+    env,
+    { fetchImpl },
+  );
+  assert.equal(canonical.status, 202);
+  assert.equal(canonical.headers.get("Access-Control-Allow-Origin"), "https://plugins.omarchy.org");
+
   const unknown = await handleRequest(request("unknown.plugin"), env, { fetchImpl });
   assert.equal(unknown.status, 404);
   const forbidden = await handleRequest(request("example.plugin", "https://attacker.example"), env, { fetchImpl });
   assert.equal(forbidden.status, 403);
-  assert.equal(database.calls.length, 2);
+  assert.equal(database.calls.length, 4);
 });
 
 test("Worker deployment files contain placeholders but no credentials", async () => {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,4 +1,5 @@
 const allowedOrigins = new Set([
+  "https://plugins.omarchy.org",
   "https://omarchyplugins.com",
   "https://www.omarchyplugins.com",
   "http://127.0.0.1:4173",


### PR DESCRIPTION
## Summary

- recognize `plugins.omarchy.org` as a production host for the engagement client
- allow the exact `https://plugins.omarchy.org` Worker origin while retaining both legacy origins
- propagate the shared browser module cache key to `20260830-02`
- add positive and adversarial hostname and CORS coverage

## Compatibility boundary

This is the non-disruptive preparation phase. It does not change:

- the current GitHub Pages custom domain
- public marketplace links or workflow deployment checks
- `api.omarchyplugins.com`
- the Worker catalog source
- DNS, Pages, or Worker deployment configuration

The updated static client and Worker must both be deployed and verified before switching the Pages custom domain. The legacy origins remain supported throughout the cutover.

## Verification

- `npm ci` — 0 vulnerabilities
- `npm test` — 286/286 passing
- `node --check` — 10 changed JavaScript files
- `git diff --check`
- two independent adversarial reviews — no findings
