### PR TITLE
Remove footer affiliation disclaimer

### DIFF
--- a/site/explore.html
+++ b/site/explore.html
@@ -223,7 +223,6 @@
         <a class="footer-status-link footer-maintainer" href="https://github.com/HANCORE-linux" target="_blank" rel="noreferrer">HANCORE <span aria-hidden="true">↗</span></a>
         <div class="footer-status-copy">
           <span class="footer-project-name">OMARCHY PLUGIN MARKETPLACE</span>
-          <p class="footer-disclaimer">Independent community project. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals.</p>
         </div>
         <div class="footer-resource-links">
           <a class="footer-status-link" href="https://github.com/omacom/omarchy-plugin-marketplace/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT LICENSE <span aria-hidden="true">↗</span></a>

--- a/site/index.html
+++ b/site/index.html
@@ -166,7 +166,6 @@
         </a>
         <div class="footer-status-copy">
           <span class="footer-project-name">OMARCHY PLUGIN MARKETPLACE</span>
-          <p class="footer-disclaimer">Independent community project. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals.</p>
         </div>
         <div class="footer-resource-links">
           <a class="footer-status-link" href="https://github.com/omacom/omarchy-plugin-marketplace/blob/main/LICENSE" target="_blank" rel="noreferrer">

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1780,7 +1780,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.plugin-author button \{[\s\S]*min-height: 24px/);
   assert.match(styles, /\.plugin-author button:hover, \.plugin-author button:focus-visible \{ color: var\(--accent\); \}/);
   assert.match(files.index, /class="footer-status"/);
-  assert.match(files.index, /HANCORE[\s\S]*OMARCHY PLUGIN MARKETPLACE[\s\S]*Independent community project\.[\s\S]*Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\.[\s\S]*GITHUB/);
+  assert.match(files.index, /HANCORE[\s\S]*OMARCHY PLUGIN MARKETPLACE[\s\S]*GITHUB/);
+  assert.doesNotMatch(files.index, /Independent community project\. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\./);
+  assert.doesNotMatch(files.explore, /Independent community project\. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\./);
   assert.doesNotMatch(files.index, /footer-tech-canvas|footer-project-canvas/);
   assert.doesNotMatch(files.app, /setupHancoreAsciiHover|setupFooterAsciiField/);
 });


### PR DESCRIPTION
## Summary
- remove the affiliation disclaimer from the marketplace footer
- keep the maintainer, project, license, and repository footer links unchanged
- cover both public footer variants with structural regression checks

## Verification
- `npm test` — 286/286 passed
- responsive Chromium review — 40/40 page, viewport, and theme checks passed
- `git diff --check`
- independent review — no findings
