### PR TITLE
Remove README affiliation disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ Event bodies contain only the catalog plugin ID and fixed action type. The marke
 
 > Nothing in this notice excludes or limits liability where exclusion or limitation is prohibited by applicable law.
 
-## Disclaimer
-
-Omarchy Plugins is an independent community project and is not affiliated with, sponsored by, or endorsed by Omarchy or 37signals.
-
 ## Credits
 
 Interface design inspired by [bjarneo](https://github.com/bjarneo)'s [ContextOwl developer documentation](https://developer.contextowl.co/docs/platform/cli).

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1285,14 +1285,15 @@ test("entry modules and their shared dependency use one cache key", async () => 
     "Nothing in this notice excludes or limits liability where exclusion or limitation is prohibited by applicable law.",
   ].join(" ");
   const securityNoticeStart = files.readme.indexOf("## Security Notice");
-  const disclaimerStart = files.readme.indexOf("## Disclaimer");
-  assert.ok(securityNoticeStart >= 0 && disclaimerStart > securityNoticeStart);
+  const creditsStart = files.readme.indexOf("## Credits");
+  assert.ok(securityNoticeStart >= 0 && creditsStart > securityNoticeStart);
   const securityNotice = files.readme
-    .slice(securityNoticeStart + "## Security Notice".length, disclaimerStart)
+    .slice(securityNoticeStart + "## Security Notice".length, creditsStart)
     .replace(/^>\s?/gm, "")
     .replace(/\s+/g, " ")
     .trim();
   assert.equal(securityNotice, expectedSecurityNotice);
+  assert.doesNotMatch(files.readme, /^## Disclaimer$|Omarchy Plugins is an independent community project and is not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\./m);
   assert.doesNotMatch(files.readme, /report suspicious plugins ASAP/);
   assert.match(files.security, /private vulnerability reporting form[\s\S]*security\/advisories\/new[\s\S]*Do not disclose credentials, exploit details, personal information, or other sensitive material in a public issue[\s\S]*may suspend or remove a listing/);
   assert.match(files.plugin, /<title>Plugin Details \| Omarchy Plugins<\/title>/);


### PR DESCRIPTION
## Summary
- remove the README affiliation disclaimer section
- preserve the complete third-party plugin Security Notice
- keep structural coverage by terminating the notice at the following Credits section

## Verification
- `node --test test/automation.test.js` — 56/56 passed
- `npm test` — 286/286 passed
- `git diff --check`
- independent review — no findings
