### PR TITLE
Add Kids taxonomy and latent Explorer community

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-plugin.yml
+++ b/.github/ISSUE_TEMPLATE/submit-plugin.yml
@@ -27,6 +27,7 @@ body:
         - Desktop
         - Developer Tools
         - Hardware
+        - Kids
         - Productivity
         - System
         - Widgets
@@ -43,8 +44,10 @@ body:
       options:
         - AI
         - Bar
+        - Education
         - Games
         - Hyprland
+        - Kids
         - Launcher
         - Media
         - Power management

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -27,6 +27,7 @@ Choose one category:
 - `Desktop`
 - `Developer Tools`
 - `Hardware`
+- `Kids`
 - `Productivity`
 - `System`
 - `Widgets`
@@ -36,8 +37,10 @@ Choose one to three tags:
 
 - `ai`
 - `bar`
+- `education`
 - `games`
 - `hyprland`
+- `kids`
 - `launcher`
 - `media`
 - `power-management`

--- a/scripts/build-explorer-data.mjs
+++ b/scripts/build-explorer-data.mjs
@@ -23,6 +23,7 @@ assertCompleteGitHistory(projectRoot);
 const clusterDefinitions = [
   ["ai", "AI & Automation", "#a78bfa", [" ai ", "llm", "gpt", "claude", "ollama", "agent", "assistant", "openai", "automation"]],
   ["games", "Games", "#f4bd62", ["game", "chess", "snake", "minesweeper", "solitaire", "quake", "doom", "arcade", "steam", "gaming"]],
+  ["kids", "Kids & Education", "#ff9fcf", []],
   ["network", "Network & VPN", "#68d6e8", ["vpn", "wireguard", "network", "wifi", "tailscale", "openvpn", "proxy", "firewall", "ssh", "connectivity"]],
   ["media", "Media & Audio", "#e896ba", ["music", "audio", "media", "spotify", "youtube", "radio", "podcast", "volume", "mpris", "album", "sound"]],
   ["productivity", "Productivity", "#b7ef51", ["todo", "task", "calendar", "agenda", "timer", "pomodoro", "notes", "mail", "gmail", "clipboard", "productivity", "reminder"]],
@@ -54,9 +55,14 @@ function tokens(plugin) {
 }
 
 function assignCluster(plugin) {
+  const sourceTags = plugin.tags || [];
+  if (plugin.category === "Kids" || sourceTags.includes("kids") || sourceTags.includes("education")) {
+    return "kids";
+  }
+  const normalizedTags = sourceTags.map((tag) => String(tag).toLowerCase());
   const text = normalizedText(plugin);
   const name = ` ${plugin.name.toLowerCase()} `;
-  const tags = ` ${(plugin.tags || []).join(" ").toLowerCase()} `;
+  const tags = ` ${normalizedTags.join(" ")} `;
   let best = clusterDefinitions.at(-1);
   let bestScore = 0;
   for (const cluster of clusterDefinitions.slice(0, -1)) {
@@ -149,7 +155,7 @@ const influence = plugins.map((plugin, index) => weightedDegree[index] * 4 + Mat
 
 const world = { width: 3400, height: 2300 };
 const targetByCluster = {
-  ai: [1120, 840], games: [760, 1280], network: [1260, 1710], media: [2220, 770],
+  ai: [1120, 840], games: [760, 1280], kids: [700, 650], network: [1260, 1710], media: [2220, 770],
   productivity: [1750, 650], system: [1740, 1210], hardware: [2260, 1430], files: [1950, 1700],
   communication: [2260, 490], appearance: [2600, 1090], developer: [1160, 1390], home: [2580, 1660],
   security: [1570, 1840], navigation: [1370, 1030], other: [1760, 880],
@@ -240,7 +246,7 @@ const clusters = clusterDefinitions.map((definition) => {
   center.x /= members.length || 1;
   center.y /= members.length || 1;
   return { id: definition.id, label: definition.label, color: definition.color, count: members.length, center };
-});
+}).filter((cluster) => cluster.count > 0);
 
 const nodes = plugins.map((plugin, index) => ({
   index,

--- a/scripts/submission.mjs
+++ b/scripts/submission.mjs
@@ -19,6 +19,7 @@ export const allowedCategories = Object.freeze([
   "Desktop",
   "Developer Tools",
   "Hardware",
+  "Kids",
   "Productivity",
   "System",
   "Widgets",
@@ -28,8 +29,10 @@ export const allowedCategories = Object.freeze([
 export const allowedTags = Object.freeze([
   "ai",
   "bar",
+  "education",
   "games",
   "hyprland",
+  "kids",
   "launcher",
   "media",
   "power-management",

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -2204,6 +2204,28 @@ test("submission tags use the curated vocabulary across web and CLI formats", ()
     })).tags,
     ["games", "media"],
   );
+  assert.deepEqual(
+    parseSubmissionBody(submissionBody({
+      category: "Kids",
+      tags: "Education, Games, Kids",
+    })),
+    {
+      repo: "https://github.com/example/omarchy-plugin",
+      category: "Kids",
+      tags: ["education", "games", "kids"],
+    },
+  );
+  assert.throws(
+    () => parseSubmissionBody(submissionBody({
+      category: "kids",
+      tags: "education, kids",
+    })),
+    /Unsupported submission category "kids"/,
+  );
+  assert.throws(
+    () => parseSubmissionBody(submissionBody({ tags: "education, child" })),
+    /Unsupported submission tags: child/,
+  );
   assert.throws(
     () => parseSubmissionBody(submissionBody({
       tags: "command-palette, search, quickapps, ai",
@@ -2485,6 +2507,13 @@ test("shared submission rules stay aligned with the public issue form", async ()
     assert.ok(form.includes(`- label: ${statement}`));
   }
   assert.equal((form.match(/required: true/g) || []).length, 8);
+  const categoryField = form.match(
+    /- type: dropdown\s+id: category([\s\S]*?)\n  - type: dropdown\s+id: tags/,
+  )?.[1];
+  assert.ok(categoryField);
+  const formCategories = [...categoryField.matchAll(/^\s+- ([A-Za-z][A-Za-z ]+)$/gm)]
+    .map((match) => match[1]);
+  assert.deepEqual(formCategories, allowedCategories);
   const tagField = form.match(
     /- type: dropdown\s+id: tags([\s\S]*?)\n  - type: input\s+id: suggested-tag/,
   )?.[1];
@@ -2506,6 +2535,20 @@ test("shared submission rules stay aligned with the public issue form", async ()
   );
 
   const guide = await readFile(new URL("../SUBMISSION.md", import.meta.url), "utf8");
+  const guideCategoryList = guide.match(
+    /Choose one category:\n\n([\s\S]*?)\n\nChoose one to three tags:/,
+  )?.[1];
+  assert.ok(guideCategoryList);
+  const guideCategories = [...guideCategoryList.matchAll(/^- `([^`]+)`$/gm)]
+    .map((match) => match[1]);
+  assert.deepEqual(guideCategories, allowedCategories);
+  const guideTagList = guide.match(
+    /Choose one to three tags:\n\n([\s\S]*?)\n\nCopy category and tag values/,
+  )?.[1];
+  assert.ok(guideTagList);
+  const guideTags = [...guideTagList.matchAll(/^- `([^`]+)`$/gm)]
+    .map((match) => match[1]);
+  assert.deepEqual(guideTags, allowedTags);
   const template = guide.match(
     /cat > \/tmp\/omarchy-plugin-submission\.md <<'EOF'\n([\s\S]*?)\nEOF/,
   )?.[1];
@@ -2525,12 +2568,6 @@ test("shared submission rules stay aligned with the public issue form", async ()
       tags: ["quickshell", "bar"],
     },
   );
-  for (const category of allowedCategories) {
-    assert.ok(guide.includes(`- \`${category}\``));
-  }
-  for (const tag of allowedTags) {
-    assert.ok(guide.includes(`- \`${tag}\``));
-  }
   assert.match(guide, /unique across all repositories/);
   assert.match(guide, /retired or renamed listings remain unavailable/);
   assert.match(guide, /io\.github\.yourname\.plugin-name/);

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -35,7 +35,7 @@ function workflowJobSource(workflow, name, nextName = "") {
   return end > start ? workflow.slice(start, end) : workflow.slice(start);
 }
 
-function createExplorerBuilderFixture(growth) {
+function createExplorerBuilderFixture(growth, plugins = []) {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "explorer-builder-history-"));
   fs.mkdirSync(path.join(directory, "scripts"));
   fs.mkdirSync(path.join(directory, "site"));
@@ -43,7 +43,7 @@ function createExplorerBuilderFixture(growth) {
   fs.copyFileSync(new URL("../scripts/explorer-growth-history.mjs", import.meta.url), path.join(directory, "scripts", "explorer-growth-history.mjs"));
   fs.writeFileSync(path.join(directory, "site", "catalog.json"), JSON.stringify({
     generatedAt: "2026-08-28T10:00:00.000Z",
-    plugins: [],
+    plugins,
   }));
   fs.writeFileSync(path.join(directory, "site", "explorer-data.json"), JSON.stringify({
     generatedAt: "2026-08-28T10:00:00.000Z",
@@ -178,6 +178,103 @@ test("Explorer growth only changes the current day or appends valid later days",
     () => assertGrowthContinuity(previous, previous.growth, "2026-08-27T18:00:00.000Z"),
     /does not extend the committed historical series/,
   );
+});
+
+test("Kids taxonomy activates its graph community without publishing empty clusters", () => {
+  const directory = createExplorerBuilderFixture(
+    [{ date: "2026-08-28", total: 7, added: 7 }],
+    [
+      {
+        id: "example.kids-category",
+        name: "Category Example",
+        author: "Example",
+        description: "Activities.",
+        category: "Kids",
+        tags: ["games"],
+        sourceType: "community",
+      },
+      {
+        id: "example.kids-tag",
+        name: "Tag Example",
+        author: "Example",
+        description: "Activities.",
+        category: "Developer Tools",
+        tags: ["kids"],
+        sourceType: "community",
+      },
+      {
+        id: "example.education-tag",
+        name: "Education Tag Example",
+        author: "Example",
+        description: "Activities.",
+        category: "Productivity",
+        tags: ["education"],
+        sourceType: "community",
+      },
+      {
+        id: "example.system-monitor",
+        name: "System Monitor",
+        author: "Example",
+        description: "System resource monitor.",
+        category: "System",
+        tags: ["system"],
+        sourceType: "community",
+      },
+      {
+        id: "example.description-neighbor",
+        name: "Reference Notes",
+        author: "Example",
+        description: "Kids education reference without curated taxonomy.",
+        category: "Productivity",
+        tags: ["quickshell"],
+        sourceType: "community",
+      },
+      {
+        id: "example.case-neighbor",
+        name: "Case Neighbor",
+        author: "Example",
+        description: "Activities.",
+        category: "Productivity",
+        tags: ["Kids", "EDUCATION"],
+        sourceType: "community",
+      },
+      {
+        id: "example.category-case-neighbor",
+        name: "Category Case Neighbor",
+        author: "Example",
+        description: "Activities.",
+        category: "kids",
+        tags: ["quickshell"],
+        sourceType: "community",
+      },
+    ],
+  );
+  try {
+    const result = spawnSync(process.execPath, ["scripts/build-explorer-data.mjs"], {
+      cwd: directory,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(fs.readFileSync(path.join(directory, "site", "explorer-data.json"), "utf8"));
+    assert.deepEqual(
+      output.clusters.map(({ id, label, count }) => ({ id, label, count })),
+      [
+        { id: "kids", label: "Kids & Education", count: 3 },
+        { id: "productivity", label: "Productivity", count: 2 },
+        { id: "system", label: "System & Monitoring", count: 1 },
+        { id: "other", label: "Other", count: 1 },
+      ],
+    );
+    for (const id of ["example.kids-category", "example.kids-tag", "example.education-tag"]) {
+      assert.equal(output.nodes.find((node) => node.id === id)?.cluster, "kids");
+    }
+    for (const id of ["example.description-neighbor", "example.case-neighbor", "example.category-case-neighbor"]) {
+      assert.notEqual(output.nodes.find((node) => node.id === id)?.cluster, "kids");
+    }
+    assert.ok(output.clusters.every((cluster) => cluster.count > 0));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("Explorer builder fails closed for shallow and truncated repositories", () => {


### PR DESCRIPTION
## Summary
- add `Kids` as a supported submission category
- add `education` and `kids` to the curated submission tags
- keep the issue form, parser, and submission guide exactly aligned
- add a latent `Kids & Education` Explorer community driven only by the exact `Kids`, `kids`, and `education` taxonomy values
- omit zero-count Explorer communities so the new filter appears only after the first matching listing is published
- preserve the three-tag limit and fail closed on unsupported near-neighbors

No existing listings, generated catalog or Explorer data, UI assets, or existing node assignments are changed.

## Verification
- `node --test test/automation.test.js` — 56/56 passed
- `node --test test/explorer.test.js` — 17/17 passed
- `npm test` — 287/287 passed
- YAML parse and syntax checks for both modified scripts
- current Explorer regeneration is byte-identical to `site/explorer-data.json`
- independent adversarial reviews — no findings