### PR TITLE
Validate Explorer clusters dynamically

### DIFF
--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -79,7 +79,17 @@ test("explorer data covers the current community catalog", () => {
   assert.ok(explorer.nodes.every((node) => node.previewThumbnail === pluginsById.get(node.id)?.previewThumbnail));
   assert.ok(explorer.nodes.every((node) => node.previewThumbnailWidth === pluginsById.get(node.id)?.previewThumbnailWidth));
   assert.ok(explorer.nodes.every((node) => node.previewThumbnailHeight === pluginsById.get(node.id)?.previewThumbnailHeight));
-  assert.equal(explorer.clusters.length, 15);
+  const nodeCountByCluster = new Map();
+  for (const node of explorer.nodes) {
+    nodeCountByCluster.set(node.cluster, (nodeCountByCluster.get(node.cluster) || 0) + 1);
+  }
+  const publishedClusterIds = explorer.clusters.map((cluster) => cluster.id);
+  assert.equal(new Set(publishedClusterIds).size, publishedClusterIds.length);
+  assert.deepEqual(new Set(publishedClusterIds), new Set(nodeCountByCluster.keys()));
+  for (const cluster of explorer.clusters) {
+    assert.ok(cluster.count > 0);
+    assert.equal(cluster.count, nodeCountByCluster.get(cluster.id));
+  }
   assert.ok(explorer.edges.length > explorer.nodes.length);
   assert.equal(explorer.method, "Local TF-IDF similarity");
 });


### PR DESCRIPTION
## Summary

- replace the fixed Explorer community count with catalog-derived consistency checks
- require unique published cluster IDs and an exact match with node-assigned clusters
- preserve fail-closed checks for non-empty communities and exact member counts

## Regression

The approval snapshots for #3725 and #3726 correctly activated the latent `Kids & Education` community through the curated `education` tag, increasing the published community count from 15 to 16. The marketplace test then failed on the inventory-specific assertion `16 !== 15`, after snapshot validation and generation had succeeded.

This change keeps the existing taxonomy behavior and validates the generated structure instead of pinning the current inventory size. It does not change the registry, catalog, Explorer output, taxonomy, or publication workflows.

## Verification

- `npm test` — 287/287
- inert `education` regression fixture — 16 communities with one `Kids & Education` member
- `node --test test/explorer.test.js` against that fixture — 17/17
- `node --check test/explorer.test.js`
- `git diff --check origin/main..HEAD`

No community plugin code was executed.
