### PR TITLE
Catalog layout idea: filter sidebar + app-style browse panel

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -763,9 +763,13 @@ html:has(.preview-lightbox[open]) { overflow: hidden; scrollbar-gutter: stable; 
 .recent-grid, .market-plugin-grid {
   display: grid; border: 0; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 24px;
 }
+/* panel height budget: 100vh minus sticky header (57px) and fixed-height footer (106px),
+   so the page's scroll floor frames the catalog exactly between them */
 .market-catalog {
-  position: relative; padding: 74px 0 100px;
+  position: relative; display: flex; height: calc(100vh - 163px); min-height: 620px;
+  padding: 24px 0 20px; flex-direction: column;
 }
+section.market-catalog[id] { scroll-margin-top: 0; }
 .market-catalog::before {
   position: absolute; top: 0; right: 0; left: 0; height: 1px;
   background: linear-gradient(to right, transparent, var(--line-soft) 9%, var(--line-soft) 91%, transparent);
@@ -870,35 +874,48 @@ html:has(.preview-lightbox[open]) { overflow: hidden; scrollbar-gutter: stable; 
   text-transform: uppercase; white-space: nowrap;
 }
 .catalog-controls .sort-control { height: auto; min-height: 43px; border-left: 1px solid var(--line); }
-.source-bar, .category-bar {
-  display: flex; min-height: 46px; padding: 7px 10px 7px 14px; border: 1px solid var(--line);
-  border-top: 0; align-items: center; gap: 12px;
+.catalog-layout {
+  display: grid; margin-top: 0; flex: 1; min-height: 0; gap: 24px;
+  grid-template-columns: 212px minmax(0, 1fr);
 }
-.source-bar > span, .category-bar > span { color: var(--muted); font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
-.source-list { display: flex; flex: 1; flex-wrap: wrap; gap: 4px; }
+.catalog-main { display: flex; min-width: 0; min-height: 0; flex-direction: column; }
+.catalog-rail {
+  display: flex; overflow: auto; max-height: 100%;
+  border: 1px solid var(--line); flex-direction: column;
+}
+.source-toggle {
+  display: grid; padding: 10px; border-bottom: 1px solid var(--line);
+  gap: 4px; grid-template-columns: repeat(2, minmax(0, 1fr));
+}
 .source-button {
-  width: auto; min-height: 29px; padding: 0 10px; border: 1px solid var(--line-strong); background: var(--code-bg); color: var(--text);
+  display: inline-flex; min-height: 46px; padding: 7px 4px; border: 1px solid var(--line-strong);
+  background: var(--code-bg); align-items: center; justify-content: center; flex-direction: column; gap: 3px; color: var(--text);
   font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: .035em; text-transform: uppercase;
 }
-.source-button span:last-child { margin-left: 7px; color: var(--muted); font-weight: 600; }
+.source-button span:last-child { color: var(--muted); font-weight: 600; }
 .source-button.active { border-color: var(--accent); background: var(--accent); color: var(--accent-contrast); }
 .source-button.active span:last-child { color: var(--accent-contrast); }
-.category-list { display: flex; flex: 1; flex-wrap: wrap; gap: 4px; }
-.category-button {
-  width: auto; min-height: 29px; padding: 0 9px; border: 1px solid var(--line); background: var(--code-bg);
+.rail-toggle { display: none; }
+.rail-panel { display: flex; min-height: 0; flex-direction: column; }
+.rail-nav { display: flex; padding: 8px 0 10px; flex-direction: column; }
+.rail-divider {
+  display: flex; margin: 12px 14px 5px; align-items: center; gap: 9px; color: var(--muted);
+  font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+}
+.rail-divider::after { height: 1px; background: var(--line); content: ""; flex: 1; }
+.category-button.is-tag span:first-child { font-family: var(--mono); font-size: 12px; letter-spacing: .02em; }
+.rail-reset {
+  min-height: 40px; border: 0; border-top: 1px solid var(--line); background: transparent;
   color: var(--muted); font-family: var(--mono); font-size: 11px; font-weight: 600;
-  line-height: 1; letter-spacing: .025em; text-transform: uppercase;
+  letter-spacing: .05em; text-transform: uppercase;
 }
-.category-button span:last-child { margin-left: 6px; color: var(--text); font-size: 11px; font-weight: 500; }
-.category-button.active {
-  border-color: var(--line-strong); background: var(--panel-2); color: var(--text);
+.rail-reset:hover { background: var(--panel-2); color: var(--text); }
+.rail-reset[hidden] { display: none; }
+.market-plugin-grid {
+  margin-top: 24px; border: 0; scroll-margin-top: 70px;
+  flex: 1; min-height: 0; overflow-y: auto; align-content: start;
+  grid-auto-rows: max-content; scrollbar-gutter: stable;
 }
-.category-bar > button {
-  border: 0; background: transparent; color: var(--muted); font-family: var(--mono);
-  font-size: 11px; font-weight: 600; letter-spacing: .025em; text-transform: uppercase;
-}
-.category-bar > button:hover { color: var(--text); }
-.market-plugin-grid { margin-top: 24px; border: 0; scroll-margin-top: 70px; }
 .market-plugin-grid .plugin-card, .recent-grid .plugin-card {
   display: flex; min-height: 0; padding: 0; overflow: hidden; border: 1px solid var(--line);
   background: var(--panel); flex-direction: column; gap: 0;
@@ -1090,8 +1107,18 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 .plugin-card-bottom .card-install { position: relative; z-index: 3; flex: none; min-height: 25px; padding: 0 7px; }
 .plugin-card-bottom .card-install [data-copy-label] { display: none; }
 .plugin-card-bottom .builtin-source-action { color: var(--text); white-space: nowrap; }
+.catalog-bottom {
+  display: flex; overflow: clip; max-height: 140px; margin-top: 20px;
+  align-items: stretch; gap: 12px;
+  transition: opacity 200ms ease, transform 200ms ease, max-height 240ms ease, margin-top 240ms ease, visibility 0s;
+}
+.catalog-bottom.is-collapsed {
+  max-height: 0; margin-top: 0; opacity: 0; pointer-events: none;
+  transform: translateY(10px); visibility: hidden;
+  transition: opacity 200ms ease, transform 200ms ease, max-height 240ms ease, margin-top 240ms ease, visibility 0s 240ms;
+}
 .catalog-pagination {
-  display: grid; margin-top: 36px; border: 1px solid var(--line);
+  display: grid; border: 1px solid var(--line); flex: 1;
   grid-template-columns: minmax(0, 1fr) 92px minmax(0, 1fr);
 }
 .catalog-pagination[hidden] { display: none; }
@@ -1119,14 +1146,14 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
 .pagination-button:not(:disabled):hover .pagination-direction { color: var(--accent); }
 .pagination-button:focus-visible { position: relative; z-index: 1; outline: 1px solid var(--accent); outline-offset: -1px; }
 .pagination-button:disabled { cursor: not-allowed; opacity: .42; }
-.catalog-view-toggle { display: flex; margin-top: 16px; justify-content: center; }
+.catalog-view-toggle { display: flex; border: 1px solid var(--line); justify-content: center; }
 .catalog-view-toggle[hidden] { display: none; }
 .catalog-view-button {
-  display: inline-flex; min-height: 44px; padding: 0 14px; border: 0; background: transparent;
+  display: inline-flex; min-height: 44px; padding: 0 18px; border: 0; background: transparent;
   align-items: center; gap: 8px; color: var(--muted); font-family: var(--mono); font-size: 10px;
   font-weight: 700; letter-spacing: .1em; text-transform: uppercase; transition: color 150ms ease;
 }
-.catalog-view-button:hover, .catalog-view-button:focus-visible { color: var(--accent); }
+.catalog-view-button:hover, .catalog-view-button:focus-visible { background: var(--panel); color: var(--accent); }
 .catalog-view-dock {
   position: fixed; z-index: 55; right: 50%; bottom: calc(20px + env(safe-area-inset-bottom));
   width: min(520px, calc(100% - 40px)); transform: translateX(50%);
@@ -1152,6 +1179,7 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   width: min(1104px, calc(100% - 40px)); margin: 0 auto; padding: 18px 0 22px;
   color: var(--muted); font-family: var(--mono);
 }
+.marketplace-page .market-footer { height: 106px; }
 .footer-status {
   position: relative; display: grid; min-height: 54px; padding-top: 12px;
   align-items: center; grid-template-columns: 1fr auto 1fr; gap: 24px;
@@ -1195,6 +1223,35 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   .recent-grid, .market-plugin-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .recent-grid .plugin-card:nth-child(n+3) { display: none; }
   .market-hero { grid-template-columns: minmax(0, 1fr) 300px; gap: 30px; }
+}
+@media (max-width: 940px) {
+  .market-catalog { display: block; height: auto; min-height: 0; padding: 74px 0 100px; }
+  .marketplace-page .market-footer { height: auto; }
+  .catalog-main { display: block; height: auto; }
+  .market-plugin-grid { min-height: 0; overflow: visible; }
+  .catalog-layout { gap: 18px; grid-template-columns: minmax(0, 1fr); }
+  .catalog-bottom { max-height: none; flex-direction: column; }
+  .catalog-rail { position: static; overflow: visible; max-height: none; }
+  .rail-toggle {
+    display: flex; min-height: 46px; padding: 0 14px; border: 0; background: transparent;
+    align-items: center; gap: 10px; color: var(--text);
+    font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  }
+  .rail-toggle svg { width: 15px; margin-left: auto; transition: transform 150ms ease; }
+  .rail-toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
+  .rail-toggle[aria-expanded="true"] { border-bottom: 1px solid var(--line); }
+  .rail-toggle-active {
+    overflow: hidden; min-width: 0; color: var(--accent);
+    letter-spacing: .035em; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .rail-toggle-active[hidden] { display: none; }
+  .rail-toggle[aria-expanded="false"] + .rail-panel { display: none; }
+  .rail-nav { padding: 10px; flex-direction: row; flex-wrap: wrap; gap: 4px; }
+  .rail-nav .category-button {
+    width: auto; min-height: 29px; padding: 0 10px; border: 1px solid var(--line);
+    border-left-width: 2px; gap: 7px; font-size: 12px;
+  }
+  .rail-divider { margin: 6px 2px 2px; flex-basis: 100%; }
 }
 @media (min-width: 761px) and (max-width: 1059px) {
   .market-nav-detail { display: none; }
@@ -1275,8 +1332,6 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   .catalog-heading { align-items: flex-start; flex-direction: column; gap: 8px; }
   .catalog-controls { grid-template-columns: 1fr; }
   .catalog-controls .sort-control { border-top: 1px solid var(--line); border-left: 0; }
-  .source-bar, .category-bar { align-items: flex-start; }
-  .source-bar > span, .category-bar > span { margin-top: 7px; }
   .plugin-preview {
     height: clamp(160px, 30vw, 220px); flex-basis: clamp(160px, 30vw, 220px);
   }

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,14 +25,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260830-02";
+} from "./engagement.js?v=20260831-01";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -59,7 +59,7 @@ import {
   searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260830-02";
+} from "./search.js?v=20260831-01";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([
@@ -153,6 +153,11 @@ const countLabel = document.querySelector("#plugin-count-label");
 const empty = document.querySelector("#empty-state");
 const sourcesRoot = document.querySelector("#source-filters");
 const categoriesRoot = document.querySelector("#category-filters");
+const clearFilters = document.querySelector("#clear-filters");
+const catalogBottom = document.querySelector(".catalog-bottom");
+const railToggle = document.querySelector("#rail-toggle");
+const railToggleActive = document.querySelector("#rail-toggle-active");
+const mobileRail = window.matchMedia("(max-width: 940px)");
 const search = document.querySelector("#search-input");
 const searchTerms = document.querySelector("#search-terms");
 const searchClear = document.querySelector("#search-clear");
@@ -1005,6 +1010,27 @@ function restoreCatalogControlFocus(token) {
   return Boolean(target);
 }
 
+// The bottom bar (pagination + browse-all) stays out of the way until the
+// grid is scrolled to its end; paging pins it so Next can be clicked repeatedly.
+let catalogBottomShown = false;
+let catalogBottomPinned = false;
+let pagingInteraction = false;
+
+function updateCatalogBottom() {
+  if (!catalogBottom) return;
+  const scrollable = grid.scrollHeight > grid.clientHeight + 1;
+  if (mobileRail.matches || !scrollable) {
+    catalogBottomShown = true;
+  } else if (catalogBottomPinned) {
+    catalogBottomShown = true;
+  } else {
+    const distance = grid.scrollHeight - grid.scrollTop - grid.clientHeight;
+    if (!catalogBottomShown && distance <= 12) catalogBottomShown = true;
+    else if (catalogBottomShown && distance > 180) catalogBottomShown = false;
+  }
+  catalogBottom.classList.toggle("is-collapsed", !catalogBottomShown);
+}
+
 function render({ historyMode = "replace", announce = false } = {}) {
   cancelViewScroll();
   const visible = filteredPlugins();
@@ -1016,6 +1042,13 @@ function render({ historyMode = "replace", announce = false } = {}) {
   const categoryPlugins = sourcePlugins().filter((plugin) => matchesCatalogFilter(plugin));
   const hasSearch = state.terms.length > 0 || Boolean(state.query.trim());
   const hasResultFilter = hasSearch || verificationFilters.has(state.sort);
+  clearFilters.hidden = state.category === "all" && !hasResultFilter;
+  const activeFilterParts = [
+    state.source === "builtin" ? "Built-in" : "",
+    state.category === "all" ? "" : catalogFilterLabel(state.category),
+  ].filter(Boolean);
+  railToggleActive.hidden = activeFilterParts.length === 0;
+  railToggleActive.textContent = activeFilterParts.join(" · ");
   count.textContent = hasResultFilter
     ? `${visible.length} of ${categoryPlugins.length}`
     : String(categoryPlugins.length);
@@ -1028,6 +1061,10 @@ function render({ historyMode = "replace", announce = false } = {}) {
   empty.hidden = visible.length !== 0;
   renderPagination(visible.length, pageState);
   placeViewDock();
+  grid.scrollTop = 0;
+  if (!pagingInteraction) catalogBottomPinned = false;
+  pagingInteraction = false;
+  updateCatalogBottom();
   updateUrl(historyMode);
   if (announce) catalogResultStatus.textContent = catalogResultMessage(visible.length, pageState);
 }
@@ -1095,25 +1132,29 @@ function renderCategories() {
   const categoryTotals = new Map();
   plugins.forEach((plugin) => categoryTotals.set(plugin.category, (categoryTotals.get(plugin.category) || 0) + 1));
   const categoryFilters = [...categoryTotals.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([nameA, totalA], [nameB, totalB]) => totalB - totalA || nameA.localeCompare(nameB))
     .map(([value, total]) => ({ value, label: value, total }));
   const tagFilters = taxonomyFilterTags
     .map((tag) => ({
       value: `tag:${tag}`,
-      label: displayTaxonomyTag(tag),
+      label: `#${tag}`,
       total: plugins.filter((plugin) => (plugin.tags || []).includes(tag)).length,
     }))
-    .filter(({ total }) => total > 0);
+    .filter(({ total }) => total > 0)
+    .sort((a, b) => b.total - a.total);
   const filters = [
     { value: "all", label: allCategoryLabel(), total: plugins.length },
     ...categoryFilters,
-    ...tagFilters,
   ];
 
-  categoriesRoot.innerHTML = filters.map(({ value, label, total }) => `
-    <button class="category-button${state.category === value ? " active" : ""}" type="button" data-category="${escapeHtml(value)}" aria-pressed="${state.category === value}">
+  const filterButton = ({ value, label, total, isTag }) => `
+    <button class="category-button${isTag ? " is-tag" : ""}${state.category === value ? " active" : ""}" type="button" data-category="${escapeHtml(value)}" aria-pressed="${state.category === value}">
       <span>${escapeHtml(label)}</span><span>${total}</span>
-    </button>`).join("");
+    </button>`;
+
+  categoriesRoot.innerHTML = filters.map((filter) => filterButton(filter)).join("") + (tagFilters.length
+    ? `<div class="rail-divider" aria-hidden="true">Tags</div>${tagFilters.map((filter) => filterButton({ ...filter, isTag: true })).join("")}`
+    : "");
 
   categoriesRoot.querySelectorAll("[data-category]").forEach((button) => {
     button.addEventListener("click", () => {
@@ -1121,8 +1162,13 @@ function renderCategories() {
       state.page = 1;
       renderCategories();
       render({ announce: true });
+      if (mobileRail.matches) setRailOpen(false);
     });
   });
+}
+
+function setRailOpen(open) {
+  railToggle.setAttribute("aria-expanded", String(open));
 }
 
 function resetFilters() {
@@ -1500,6 +1546,8 @@ async function init() {
 
   const changePage = (offset) => {
     state.page += offset;
+    pagingInteraction = true;
+    catalogBottomPinned = true;
     render({ historyMode: "push", announce: true });
     const firstResult = grid.querySelector(".plugin-card-link");
     firstResult?.focus({ preventScroll: true });
@@ -1548,7 +1596,12 @@ async function init() {
     if (!restoreCatalogControlFocus(controlFocus) && catalogHadFocus) focusCatalogResult();
   });
 
-  document.querySelector("#clear-filters").addEventListener("click", resetFilters);
+  railToggle.addEventListener("click", () => {
+    setRailOpen(railToggle.getAttribute("aria-expanded") !== "true");
+  });
+  grid.addEventListener("scroll", updateCatalogBottom, { passive: true });
+  window.addEventListener("resize", updateCatalogBottom);
+  clearFilters.addEventListener("click", resetFilters);
   document.querySelector("#empty-reset").addEventListener("click", resetFilters);
 }
 

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/explore-search.js
+++ b/site/assets/js/explore-search.js
@@ -2,7 +2,7 @@ import {
   matchesDirectSearch,
   matchesDraftSearchTerm,
   parseSearchDraft,
-} from "./search.js?v=20260830-02";
+} from "./search.js?v=20260831-01";
 
 export function repositoryPublisher(repo) {
   try {

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -1,5 +1,5 @@
-import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260830-02";
-import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260830-02";
+import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260831-01";
+import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260831-01";
 import { inclusiveDayCount, inclusiveRangeStart } from "./growth-range.js?v=20260828-18";
 
 const number = new Intl.NumberFormat("en-US");

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260830-02";
+} from "./engagement.js?v=20260831-01";
 
 function safeGitHubWebUrl(value) {
   try {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260831-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/develop.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000">
     <title>Explore Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260831-01">
     <link rel="stylesheet" href="assets/css/explore.css?v=20260828-27">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
@@ -238,6 +238,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/explore.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260831-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -78,6 +78,21 @@
           <p><span id="plugin-count">0</span> <span id="plugin-count-label">community plugins</span></p>
         </div>
 
+        <div class="catalog-layout">
+          <aside class="catalog-rail" aria-label="Plugin filters">
+            <button id="rail-toggle" class="rail-toggle" type="button" aria-expanded="false" aria-controls="rail-panel">
+              <span>Filters</span>
+              <span id="rail-toggle-active" class="rail-toggle-active" hidden></span>
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 10 4 4 4-4"/></svg>
+            </button>
+            <div id="rail-panel" class="rail-panel">
+              <div id="source-filters" class="source-toggle" role="group" aria-label="Plugin source"></div>
+              <nav id="category-filters" class="rail-nav" aria-label="Plugin categories and tags"></nav>
+              <button id="clear-filters" class="rail-reset" type="button" hidden>Reset filters <span aria-hidden="true">×</span></button>
+            </div>
+          </aside>
+
+          <div class="catalog-main">
         <div class="catalog-controls">
           <div class="market-search">
             <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
@@ -111,23 +126,13 @@
           </label>
         </div>
 
-        <div class="source-bar">
-          <span>Source</span>
-          <div id="source-filters" class="source-list"></div>
-        </div>
-
-        <div class="category-bar">
-          <span>Filter</span>
-          <div id="category-filters" class="category-list"></div>
-          <button id="clear-filters" type="button">Reset</button>
-        </div>
-
         <div id="plugin-grid" class="plugin-grid market-plugin-grid"></div>
         <div id="empty-state" class="empty-state" hidden>
           <h3>No plugins found</h3>
           <p>Try another search or clear the active filters.</p>
           <button class="button" id="empty-reset" type="button">Clear filters</button>
         </div>
+        <div class="catalog-bottom">
         <nav id="catalog-pagination" class="catalog-pagination" aria-label="Plugin result pages">
           <button id="page-previous" class="pagination-button pagination-previous" type="button">
             <span class="pagination-direction"><span aria-hidden="true">←</span> Previous</span>
@@ -146,6 +151,9 @@
             <span id="catalog-view-label">Browse all plugins</span>
             <span aria-hidden="true">↓</span>
           </button>
+        </div>
+        </div>
+          </div>
         </div>
         <span id="catalog-result-status" class="sr-only" role="status" aria-live="polite"></span>
       </section>
@@ -185,6 +193,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/app.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260831-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -37,6 +37,6 @@
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260831-01">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/publish.js?v=20260831-01"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1183,15 +1183,15 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260830-02");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260830-02");
-  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260830-02");
+  assert.equal(keys[0], "20260831-01");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260831-01");
+  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260831-01");
   assert.equal(files.exploreJs.match(/growth-range\.js\?v=([^"']+)/)?.[1], "20260828-18");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
   assert.equal(new Set(styleKeys).size, 1);
-  assert.equal(styleKeys[0], "20260820-21");
+  assert.equal(styleKeys[0], "20260831-01");
   const faviconKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/favicon\.svg\?v=([^"']+)/)?.[1]);
   assert.ok(faviconKeys.every(Boolean));
@@ -1745,9 +1745,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.listing-check-row \{[\s\S]*grid-template-columns: minmax\(130px, \.8fr\) minmax\(0, 1\.2fr\)/);
   assert.match(styles, /\.pagination-summary \{[\s\S]*color: var\(--muted\)/);
   assert.match(styles, /\.pagination-direction \{[\s\S]*color: var\(--muted\)/);
-  assert.match(styles, /\.catalog-view-toggle \{ display: flex; margin-top: 16px; justify-content: center; \}/);
+  assert.match(styles, /\.catalog-view-toggle \{ display: flex; border: 1px solid var\(--line\); justify-content: center; \}/);
   assert.match(styles, /\.catalog-view-button \{[\s\S]*min-height: 44px;[\s\S]*font-family: var\(--mono\);[\s\S]*text-transform: uppercase/);
-  assert.match(styles, /\.catalog-view-button:hover, \.catalog-view-button:focus-visible \{ color: var\(--accent\); \}/);
+  assert.match(styles, /\.catalog-view-button:hover, \.catalog-view-button:focus-visible \{ background: var\(--panel\); color: var\(--accent\); \}/);
   assert.match(styles, /\.catalog-view-dock \{[\s\S]*position: fixed; z-index: 55;[\s\S]*bottom: calc\(20px \+ env\(safe-area-inset-bottom\)\)/);
   assert.match(styles, /\.catalog-view-dock button \{[\s\S]*min-height: 48px;[\s\S]*background: var\(--panel-2\);[\s\S]*text-transform: uppercase/);
   assert.match(styles, /\.catalog-show-all \.toast \{ bottom: calc\(88px \+ env\(safe-area-inset-bottom\)\); \}/);


### PR DESCRIPTION
Hey! I've been playing with the browse page layout and ended up rebuilding the catalog section quite a bit. No pressure to merge — just thought it looks better and wanted to show you. **Do you like my layout, or do you like yours better?** Totally fine either way :)

## Before

The Source and Filter rows stack as two full-width chip bars above the grid, and the whole page scrolls past everything:

![before](https://raw.githubusercontent.com/TripleU613/omarchy-plugin-marketplace/catalog-layout-assets/pr-before.png)

## After

The filters move into a left sidebar (source toggle up top, categories sorted by count, tags in their own `#` section, Reset only appears when a filter is active), and the catalog becomes a viewport-height panel framed between the header and footer — only the cards scroll inside it:

![after](https://raw.githubusercontent.com/TripleU613/omarchy-plugin-marketplace/catalog-layout-assets/pr-after.png)

The pagination + "browse all" controls merge into one bottom bar that stays out of the way and slides in when you've scrolled through the cards (it stays pinned while you're paging, and hides again when the filters change):

![after scrolled](https://raw.githubusercontent.com/TripleU613/omarchy-plugin-marketplace/catalog-layout-assets/pr-after-scrolled.png)

## What changed

- **Sidebar rail** instead of the two chip bars — reuses the existing `.sidebar-link` visual language from the develop/publish pages, so it feels native. Categories are count-descending, tags are visually separated (`#ai`, `#security`, `#games`), and the Community/Built-in toggle shows both counts.
- **App-style panel**: the catalog section is `calc(100vh - header - footer)` tall, so scrolling to the bottom of the page frames it exactly between the sticky header and the footer, and the card grid scrolls internally (`grid-auto-rows: max-content` was needed so the definite-height grid doesn't compress the cards).
- **Bottom bar reveal**: pagination and the browse-all toggle share one row, hidden until the grid is scrolled to its end, with a smooth expand/collapse (respects `prefers-reduced-motion`).
- **Mobile (≤940px)** falls back to normal document flow with a collapsible "Filters" disclosure that shows the active filter inline and auto-closes after picking a category.
- Deep links (`?category=tag:ai` etc.), keyboard focus restore, and the show-all dock all still work; shared cache keys bumped and the pinned test assertions updated — all 287 tests pass.

Happy to adjust anything (rail width, the reveal behavior, panel heights) or just close this if you prefer the current layout!
