### PR TITLE
Fix Wayfinder standard-installation metadata

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3374,6 +3374,7 @@
             "bar",
             "quickshell"
           ],
+          "manifestPath": "manifest.json",
           "installation": {
             "mode": "manual",
             "note": "This plugin requires additional setup before it can be enabled. Follow the upstream installation instructions."


### PR DESCRIPTION
## Summary

- Add the explicit root `manifestPath` to the Wayfinder registry entry.
- Make the existing manual-installation override eligible for the guarded standard-installation workflow.

## Context

Related to #3160.

Wayfinder already has the required manual `installation` override, but its legacy registry entry relies on the implicit root-manifest default. `sourceWithStandardInstallation()` requires `manifestPath === "manifest.json"` explicitly, so the request is rejected before its normal verification and approval checks run.

This change does not remove the manual override or bypass the automated baseline and maintainer approval requirements. It only makes the existing root layout explicit.

## Validation

- `npm test` — 287 tests passed
- `git diff --check` — passed
- Standard-installation structural eligibility check — passed

`npm run build` could not complete locally because the unauthenticated GitHub API rate limit was exhausted before catalogue generation began. No generated files changed; the repository workflow can run the build with its normal GitHub credentials.