### PR TITLE
Report security baseline scan-limit failures

### DIFF
--- a/.github/workflows/validate-plugin-update.yml
+++ b/.github/workflows/validate-plugin-update.yml
@@ -98,20 +98,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set +e
           node scripts/security-baseline.mjs \
             --metadata=update-validation-metadata.json \
             --json=update-security-baseline.json \
             > update-security-baseline-report.md
-          result="$(jq -r '.outcome' update-security-baseline.json)"
-          disposition="$(jq -r '.verifiedPublicationDisposition' update-security-baseline.json)"
-          case "$result" in
-            passed|review-required|needs-fixes) ;;
-            *) echo "Unexpected security baseline result: $result" >&2; exit 1 ;;
-          esac
-          case "$disposition" in
-            clear|review-required|needs-fixes) ;;
-            *) echo "Unexpected verified publication disposition: $disposition" >&2; exit 1 ;;
-          esac
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            result="$(jq -r '.outcome' update-security-baseline.json)"
+            disposition="$(jq -r '.verifiedPublicationDisposition' update-security-baseline.json)"
+            case "$result" in
+              passed|review-required|needs-fixes) ;;
+              *) echo "Unexpected security baseline result: $result" >&2; exit 1 ;;
+            esac
+            case "$disposition" in
+              clear|review-required|needs-fixes) ;;
+              *) echo "Unexpected verified publication disposition: $disposition" >&2; exit 1 ;;
+            esac
+          elif [ "$status" -eq 3 ]; then
+            test ! -e update-security-baseline.json
+            IFS= read -r marker < update-security-baseline-report.md
+            grep -Fqx '<!-- marketplace-security-baseline-error:v4 -->' <<< "$marker"
+            result="scan-error"
+            disposition=""
+          else
+            exit "$status"
+          fi
           echo "result=$result" >> "$GITHUB_OUTPUT"
           echo "disposition=$disposition" >> "$GITHUB_OUTPUT"
 
@@ -231,6 +244,7 @@ jobs:
         env:
           VALIDATION_RESULT: ${{ needs.analyze.outputs.validation_result }}
           BASELINE_RESULT: ${{ needs.analyze.outputs.baseline_result }}
+          BASELINE_DISPOSITION: ${{ needs.analyze.outputs.baseline_disposition }}
         run: |
           set -euo pipefail
           reports="$RUNNER_TEMP/plugin-update-reports"
@@ -240,10 +254,30 @@ jobs:
           fi
           actual_files="$(cd "$reports" && find . -type f -printf '%P\n' | sort)"
           if [ "$VALIDATION_RESULT" = validated ]; then
-            test -n "$BASELINE_RESULT"
+            case "$BASELINE_RESULT" in
+              passed|review-required|needs-fixes)
+                case "$BASELINE_DISPOSITION" in
+                  clear|review-required|needs-fixes) ;;
+                  *) echo "Validated baseline disposition is invalid." >&2; exit 1 ;;
+                esac
+                marker_pattern='^<!-- marketplace-security-baseline:v4 [A-Za-z0-9_-]+ -->$'
+                ;;
+              scan-error)
+                test -z "$BASELINE_DISPOSITION"
+                marker_pattern='^<!-- marketplace-security-baseline-error:v4 -->$'
+                ;;
+              *) echo "Validated baseline result is invalid." >&2; exit 1 ;;
+            esac
             expected_files="$(printf '%s\n' SHA256SUMS update-security-baseline-report.md update-validation-report.md | sort)"
-          else
+            IFS= read -r marker < "$reports/update-security-baseline-report.md"
+            grep -Eq "$marker_pattern" <<< "$marker"
+          elif [ "$VALIDATION_RESULT" = needs-fixes ]; then
+            test -z "$BASELINE_RESULT"
+            test -z "$BASELINE_DISPOSITION"
             expected_files="$(printf '%s\n' SHA256SUMS update-validation-report.md | sort)"
+          else
+            echo "Update validation result is invalid." >&2
+            exit 1
           fi
           test "$actual_files" = "$expected_files"
           (cd "$reports" && sha256sum --check SHA256SUMS)
@@ -313,6 +347,7 @@ jobs:
           EXPECTED_TITLE: ${{ github.event.issue.title }}
           EXPECTED_BODY: ${{ github.event.issue.body }}
           RESULT: ${{ needs.analyze.outputs.validation_result }}
+          BASELINE_RESULT: ${{ needs.analyze.outputs.baseline_result }}
           BASELINE_DISPOSITION: ${{ needs.analyze.outputs.baseline_disposition }}
         run: |
           set -euo pipefail
@@ -329,7 +364,17 @@ jobs:
           remove_label approved-and-verified
           remove_label approved-for-listing
           remove_label maintainer-verified
-          if [ "$RESULT" = validated ]; then
+          if [ "$RESULT" = validated ] && [ "$BASELINE_RESULT" = scan-error ]; then
+            test -z "$BASELINE_DISPOSITION"
+            gh issue edit "$ISSUE_NUMBER" --add-label needs-fixes
+            remove_label validated
+            remove_label security-needs-fixes
+            remove_label security-review-required
+          elif [ "$RESULT" = validated ]; then
+            case "$BASELINE_RESULT" in
+              passed|review-required|needs-fixes) ;;
+              *) echo "A validated update requires a complete security baseline." >&2; exit 1 ;;
+            esac
             gh issue edit "$ISSUE_NUMBER" --add-label validated
             remove_label needs-fixes
             case "$BASELINE_DISPOSITION" in
@@ -347,11 +392,16 @@ jobs:
                 ;;
               *) echo "A validated update requires a security disposition." >&2; exit 1 ;;
             esac
-          else
+          elif [ "$RESULT" = needs-fixes ]; then
+            test -z "$BASELINE_RESULT"
+            test -z "$BASELINE_DISPOSITION"
             gh issue edit "$ISSUE_NUMBER" --add-label needs-fixes
             remove_label validated
             remove_label security-needs-fixes
             remove_label security-review-required
+          else
+            echo "Update validation result is invalid." >&2
+            exit 1
           fi
 
       - name: Clear stale update workflow status

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -107,20 +107,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set +e
           node scripts/security-baseline.mjs \
             --metadata=validation-metadata.json \
             --json=security-baseline.json \
             > security-baseline-report.md
-          result="$(jq -r '.outcome' security-baseline.json)"
-          disposition="$(jq -r '.verifiedPublicationDisposition' security-baseline.json)"
-          case "$result" in
-            passed|review-required|needs-fixes) ;;
-            *) echo "Unexpected security baseline result: $result" >&2; exit 1 ;;
-          esac
-          case "$disposition" in
-            clear|review-required|needs-fixes) ;;
-            *) echo "Unexpected verified publication disposition: $disposition" >&2; exit 1 ;;
-          esac
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            result="$(jq -r '.outcome' security-baseline.json)"
+            disposition="$(jq -r '.verifiedPublicationDisposition' security-baseline.json)"
+            case "$result" in
+              passed|review-required|needs-fixes) ;;
+              *) echo "Unexpected security baseline result: $result" >&2; exit 1 ;;
+            esac
+            case "$disposition" in
+              clear|review-required|needs-fixes) ;;
+              *) echo "Unexpected verified publication disposition: $disposition" >&2; exit 1 ;;
+            esac
+          elif [ "$status" -eq 3 ]; then
+            test ! -e security-baseline.json
+            IFS= read -r marker < security-baseline-report.md
+            grep -Fqx '<!-- marketplace-security-baseline-error:v4 -->' <<< "$marker"
+            result="scan-error"
+            disposition=""
+          else
+            exit "$status"
+          fi
           echo "result=$result" >> "$GITHUB_OUTPUT"
           echo "disposition=$disposition" >> "$GITHUB_OUTPUT"
 
@@ -261,6 +274,7 @@ jobs:
         env:
           VALIDATION_RESULT: ${{ needs.validate.outputs.validation_result }}
           BASELINE_RESULT: ${{ needs.validate.outputs.baseline_result }}
+          BASELINE_DISPOSITION: ${{ needs.validate.outputs.baseline_disposition }}
         run: |
           set -euo pipefail
           reports="$RUNNER_TEMP/validation-reports"
@@ -270,10 +284,30 @@ jobs:
           fi
           actual_files="$(cd "$reports" && find . -type f -printf '%P\n' | sort)"
           if [ "$VALIDATION_RESULT" = validated ]; then
-            test -n "$BASELINE_RESULT"
+            case "$BASELINE_RESULT" in
+              passed|review-required|needs-fixes)
+                case "$BASELINE_DISPOSITION" in
+                  clear|review-required|needs-fixes) ;;
+                  *) echo "Validated baseline disposition is invalid." >&2; exit 1 ;;
+                esac
+                marker_pattern='^<!-- marketplace-security-baseline:v4 [A-Za-z0-9_-]+ -->$'
+                ;;
+              scan-error)
+                test -z "$BASELINE_DISPOSITION"
+                marker_pattern='^<!-- marketplace-security-baseline-error:v4 -->$'
+                ;;
+              *) echo "Validated baseline result is invalid." >&2; exit 1 ;;
+            esac
             expected_files="$(printf '%s\n' SHA256SUMS security-baseline-report.md validation-report.md | sort)"
-          else
+            IFS= read -r marker < "$reports/security-baseline-report.md"
+            grep -Eq "$marker_pattern" <<< "$marker"
+          elif [ "$VALIDATION_RESULT" = needs-fixes ]; then
+            test -z "$BASELINE_RESULT"
+            test -z "$BASELINE_DISPOSITION"
             expected_files="$(printf '%s\n' SHA256SUMS validation-report.md | sort)"
+          else
+            echo "Validation result is invalid." >&2
+            exit 1
           fi
           test "$actual_files" = "$expected_files"
           (cd "$reports" && sha256sum --check SHA256SUMS)
@@ -333,6 +367,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RESULT: ${{ needs.validate.outputs.validation_result }}
+          BASELINE_RESULT: ${{ needs.validate.outputs.baseline_result }}
           BASELINE_DISPOSITION: ${{ needs.validate.outputs.baseline_disposition }}
         run: |
           set -euo pipefail
@@ -348,7 +383,17 @@ jobs:
           remove_label approved-and-verified
           remove_label approved-for-listing
 
-          if [ "$RESULT" = "validated" ]; then
+          if [ "$RESULT" = "validated" ] && [ "$BASELINE_RESULT" = "scan-error" ]; then
+            test -z "$BASELINE_DISPOSITION"
+            gh issue edit "$ISSUE_NUMBER" --add-label needs-fixes
+            remove_label validated
+            remove_label security-needs-fixes
+            remove_label security-review-required
+          elif [ "$RESULT" = "validated" ]; then
+            case "$BASELINE_RESULT" in
+              passed|review-required|needs-fixes) ;;
+              *) echo "A validated submission requires a complete security baseline." >&2; exit 1 ;;
+            esac
             gh issue edit "$ISSUE_NUMBER" --add-label validated
             remove_label needs-fixes
             case "$BASELINE_DISPOSITION" in
@@ -369,11 +414,16 @@ jobs:
                 exit 1
                 ;;
             esac
-          else
+          elif [ "$RESULT" = "needs-fixes" ]; then
+            test -z "$BASELINE_RESULT"
+            test -z "$BASELINE_DISPOSITION"
             gh issue edit "$ISSUE_NUMBER" --add-label needs-fixes
             remove_label validated
             remove_label security-needs-fixes
             remove_label security-review-required
+          else
+            echo "Validation result is invalid." >&2
+            exit 1
           fi
 
       - name: Record validation publication failure

--- a/scripts/security-baseline.mjs
+++ b/scripts/security-baseline.mjs
@@ -24,6 +24,8 @@ function requiredArgument(name) {
   return value;
 }
 
+export const securityBaselineScanLimitExitCode = 3;
+
 let reportContext = "submission";
 
 async function main() {
@@ -71,6 +73,6 @@ if (isMain) {
     const code = error?.code || "security-baseline-unavailable";
     process.stdout.write(buildSecurityBaselineFailureReport(error, { context: reportContext }));
     console.error(`Automated security baseline failed [${code}]`);
-    process.exitCode = 2;
+    process.exitCode = code === "security-baseline-scan-limit" ? securityBaselineScanLimitExitCode : 2;
   });
 }

--- a/test/security-baseline.test.js
+++ b/test/security-baseline.test.js
@@ -24,6 +24,7 @@ import {
   securityBaselineEligibleForVerifiedListing,
   securityBaselineErrorMarker,
   securityBaselineMarkerPrefix,
+  securityBaselineScanLimitExitCode,
   securityAssetProbeFileLimit,
   verifiedPublicationDisposition,
   securitySnapshotByteLimit,
@@ -1612,6 +1613,7 @@ test("baseline failures are fail-closed but still actionable", () => {
   assert.match(report, /dist\/runtime\.js/);
   assert.match(report, /No approval is possible/);
   assert.match(report, /not a security audit, certification, warranty, or endorsement/);
+  assert.equal(securityBaselineScanLimitExitCode, 3);
 });
 
 test("reports are actionable, commit-bound, and carry the required disclaimer", () => {

--- a/test/workflow-optimization.test.js
+++ b/test/workflow-optimization.test.js
@@ -14,6 +14,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import {
+  securityBaselineErrorMarker,
+  securityBaselineMarkerPrefix,
+} from "../scripts/security-baseline-policy.mjs";
 
 const root = new URL("../", import.meta.url);
 
@@ -89,6 +93,18 @@ if (args[0] === "api" && args.includes("--method") && args.includes("DELETE")) {
   process.exit(0);
 }
 if (args[0] === "api" && args.includes("--paginate")) {
+  process.exit(0);
+}
+if (args[0] === "api" && !args.includes("--method")) {
+  process.stdout.write(JSON.stringify(state));
+  process.exit(0);
+}
+if (args[0] === "issue" && args[1] === "edit") {
+  const labelIndex = args.indexOf("--add-label");
+  if (labelIndex < 0 || !args[labelIndex + 1]) process.exit(2);
+  const label = args[labelIndex + 1];
+  if (!state.labels.some((item) => item.name === label)) state.labels.push({ name: label });
+  writeFileSync(process.env.GH_STATE, JSON.stringify(state));
   process.exit(0);
 }
 if (args[0] === "issue" && args[1] === "comment") {
@@ -187,6 +203,275 @@ test("per-issue analysis is isolated from one globally locked mutation job", asy
     }
     for (const step of workflow.mutationSteps) {
       assert.ok(mutation.includes(`- name: ${step}`), `${workflow.name}: ${step}`);
+    }
+  }
+});
+
+test("security scan limits produce a publishable error state while other baseline failures stay hard", async () => {
+  const scenarios = [
+    {
+      workflow: "validate-submission.yml",
+      report: "security-baseline-report.md",
+      json: "security-baseline.json",
+    },
+    {
+      workflow: "validate-plugin-update.yml",
+      report: "update-security-baseline-report.md",
+      json: "update-security-baseline.json",
+    },
+  ];
+  const cases = [
+    {
+      name: "complete baseline",
+      mode: "success",
+      expectedStatus: 0,
+      expectedOutput: "result=passed\ndisposition=clear\n",
+    },
+    {
+      name: "scan limit",
+      mode: "scan-limit",
+      expectedStatus: 0,
+      expectedOutput: "result=scan-error\ndisposition=\n",
+    },
+    {
+      name: "unavailable snapshot",
+      mode: "unavailable",
+      expectedStatus: 2,
+      expectedOutput: "",
+    },
+    {
+      name: "scan limit with a success marker",
+      mode: "wrong-marker",
+      expectedStatus: 1,
+      expectedOutput: "",
+    },
+    {
+      name: "scan limit with legacy v1 error marker",
+      mode: "legacy-v1-marker",
+      expectedStatus: 1,
+      expectedOutput: "",
+    },
+    {
+      name: "scan limit with legacy v3 error marker",
+      mode: "legacy-v3-marker",
+      expectedStatus: 1,
+      expectedOutput: "",
+    },
+    {
+      name: "scan limit with unknown future error marker",
+      mode: "future-marker",
+      expectedStatus: 1,
+      expectedOutput: "",
+    },
+    {
+      name: "scan limit with a canonical result file",
+      mode: "unexpected-json",
+      expectedStatus: 1,
+      expectedOutput: "",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const workflow = await readFile(
+      new URL(`.github/workflows/${scenario.workflow}`, root),
+      "utf8",
+    );
+    const script = workflowStepScript(workflow, "Run automated security baseline");
+    for (const item of cases) {
+      const directory = await mkdtemp(join(tmpdir(), "marketplace-baseline-exit-"));
+      const bin = join(directory, "bin");
+      const output = join(directory, "output");
+      await mkdir(bin);
+      await writeFile(join(bin, "node"), `#!/bin/sh
+set -eu
+json=""
+for argument in "$@"; do
+  case "$argument" in
+    --json=*) json="\${argument#--json=}" ;;
+  esac
+done
+test -n "$json"
+case "$FAKE_BASELINE_MODE" in
+  success)
+    printf '%s\\n' '{"outcome":"passed","verifiedPublicationDisposition":"clear"}' > "$json"
+    printf '%s\\n' '${securityBaselineMarkerPrefix}e30 -->' 'Complete report'
+    exit 0
+    ;;
+  scan-limit)
+    rm -f "$json"
+    printf '%s\\n' '${securityBaselineErrorMarker}' 'dist/runtime.js exceeds the limit'
+    exit 3
+    ;;
+  unavailable)
+    rm -f "$json"
+    printf '%s\\n' '${securityBaselineErrorMarker}' 'Snapshot unavailable'
+    exit 2
+    ;;
+  wrong-marker)
+    rm -f "$json"
+    printf '%s\\n' '${securityBaselineMarkerPrefix}e30 -->' 'Wrong report'
+    exit 3
+    ;;
+  legacy-v1-marker)
+    rm -f "$json"
+    printf '%s\\n' '<!-- marketplace-security-baseline-error:v1 -->' 'Outdated report'
+    exit 3
+    ;;
+  legacy-v3-marker)
+    rm -f "$json"
+    printf '%s\\n' '<!-- marketplace-security-baseline-error:v3 -->' 'Outdated report'
+    exit 3
+    ;;
+  future-marker)
+    rm -f "$json"
+    printf '%s\\n' '<!-- marketplace-security-baseline-error:v99 -->' 'Unknown report'
+    exit 3
+    ;;
+  unexpected-json)
+    printf '%s\\n' '{}' > "$json"
+    printf '%s\\n' '${securityBaselineErrorMarker}' 'Unexpected result file'
+    exit 3
+    ;;
+  *) exit 99 ;;
+esac
+`);
+      await chmod(join(bin, "node"), 0o755);
+      try {
+        const execution = runWorkflowScript(script, {
+          cwd: directory,
+          env: {
+            FAKE_BASELINE_MODE: item.mode,
+            GITHUB_OUTPUT: output,
+            PATH: `${bin}:${process.env.PATH}`,
+          },
+        });
+        assert.equal(
+          execution.status,
+          item.expectedStatus,
+          `${scenario.workflow}, ${item.name}: ${execution.stderr}`,
+        );
+        const actualOutput = await readFile(output, "utf8").catch(() => "");
+        assert.equal(actualOutput, item.expectedOutput, `${scenario.workflow}, ${item.name}`);
+        assert.equal(
+          await readFile(join(directory, scenario.report), "utf8").then(() => true, () => false),
+          true,
+          `${scenario.workflow}, ${item.name}`,
+        );
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("security scan-limit reports publish fail-closed without retaining trust labels", async () => {
+  const scenarios = [
+    {
+      workflow: "validate-submission.yml",
+      verifyStep: "Verify analyzed validation reports",
+      publishStep: "Publish automated security baseline",
+      labelsStep: "Update validation labels",
+      reportsDirectory: "validation-reports",
+      validationReport: "validation-report.md",
+      baselineReport: "security-baseline-report.md",
+      title: "[Plugin]: Example",
+      body: "Submission body",
+      retainedLabel: "submission",
+      extraTrustLabels: [],
+    },
+    {
+      workflow: "validate-plugin-update.yml",
+      verifyStep: "Verify analyzed update reports",
+      publishStep: "Publish update security baseline",
+      labelsStep: "Update plugin update labels",
+      reportsDirectory: "plugin-update-reports",
+      validationReport: "update-validation-report.md",
+      baselineReport: "update-security-baseline-report.md",
+      title: "[Verify]: Example",
+      body: "Update body",
+      retainedLabel: "plugin-update",
+      extraTrustLabels: ["maintainer-verified"],
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const workflow = await readFile(
+      new URL(`.github/workflows/${scenario.workflow}`, root),
+      "utf8",
+    );
+    const verifyScript = workflowStepScript(workflow, scenario.verifyStep);
+    const publishScript = workflowStepScript(workflow, scenario.publishStep);
+    const labelsScript = workflowStepScript(workflow, scenario.labelsStep);
+    const directory = await mkdtemp(join(tmpdir(), "marketplace-baseline-publication-"));
+    const reports = join(directory, scenario.reportsDirectory);
+    const baselineReport = [
+      securityBaselineErrorMarker,
+      "## Automated security baseline",
+      "",
+      "The static scan could not safely process `dist/runtime.js` within its configured limits.",
+      "",
+    ].join("\n");
+    try {
+      await createReportArtifact(reports, {
+        [scenario.validationReport]: "Validation passed.\n",
+        [scenario.baselineReport]: baselineReport,
+      });
+      const verify = runWorkflowScript(verifyScript, {
+        cwd: directory,
+        env: {
+          BASELINE_DISPOSITION: "",
+          BASELINE_RESULT: "scan-error",
+          RUNNER_TEMP: directory,
+          VALIDATION_RESULT: "validated",
+        },
+      });
+      assert.equal(verify.status, 0, `${scenario.workflow}: ${verify.stderr}`);
+
+      const staleLabels = [
+        scenario.retainedLabel,
+        "validated",
+        "approved-and-verified",
+        "approved-for-listing",
+        ...scenario.extraTrustLabels,
+        "security-needs-fixes",
+        "security-review-required",
+      ];
+      const stub = await createIssueMutationStub(directory, {
+        state: "open",
+        title: scenario.title,
+        body: scenario.body,
+        labels: staleLabels.map((name) => ({ name })),
+      });
+      const mutationEnv = {
+        BASELINE_DISPOSITION: "",
+        BASELINE_RESULT: "scan-error",
+        EXPECTED_BODY: scenario.body,
+        EXPECTED_TITLE: scenario.title,
+        GH_CALLS: stub.calls,
+        GH_STATE: stub.state,
+        GITHUB_REPOSITORY: "example/marketplace",
+        ISSUE_NUMBER: "42",
+        PATH: `${stub.bin}:${process.env.PATH}`,
+        RESULT: "validated",
+        RUNNER_TEMP: directory,
+      };
+      const publish = runWorkflowScript(publishScript, { cwd: directory, env: mutationEnv });
+      assert.equal(publish.status, 0, `${scenario.workflow}: ${publish.stderr}`);
+      const labels = runWorkflowScript(labelsScript, { cwd: directory, env: mutationEnv });
+      assert.equal(labels.status, 0, `${scenario.workflow}: ${labels.stderr}`);
+
+      const state = JSON.parse(await readFile(stub.state, "utf8"));
+      assert.deepEqual(
+        state.labels.map(({ name }) => name).sort(),
+        [scenario.retainedLabel, "needs-fixes"].sort(),
+        scenario.workflow,
+      );
+      assert.equal(state.comments.length, 1, scenario.workflow);
+      assert.equal(state.comments[0], baselineReport, scenario.workflow);
+      assert.match(state.comments[0], /dist\/runtime\.js/);
+      assert.doesNotMatch(state.comments[0], /marketplace-security-baseline:v[0-9]+ /);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
     }
   }
 });
@@ -384,23 +669,70 @@ test("submission report consumer rejects tampering, links, and unexpected files"
       files: { "validation-report.md": "validation\n" },
       result: "needs-fixes",
       baseline: "",
+      disposition: "",
       expectedStatus: 0,
     },
     {
       name: "valid accepted submission",
       files: {
         "validation-report.md": "validation\n",
-        "security-baseline-report.md": "baseline\n",
+        "security-baseline-report.md": `${securityBaselineMarkerPrefix}e30 -->\nbaseline\n`,
       },
       result: "validated",
       baseline: "passed",
+      disposition: "clear",
       expectedStatus: 0,
     },
+    {
+      name: "valid scan-limit report",
+      files: {
+        "validation-report.md": "validation\n",
+        "security-baseline-report.md": `${securityBaselineErrorMarker}\nscan limit\n`,
+      },
+      result: "validated",
+      baseline: "scan-error",
+      disposition: "",
+      expectedStatus: 0,
+    },
+    {
+      name: "scan-limit result with success marker",
+      files: {
+        "validation-report.md": "validation\n",
+        "security-baseline-report.md": `${securityBaselineMarkerPrefix}e30 -->\nbaseline\n`,
+      },
+      result: "validated",
+      baseline: "scan-error",
+      disposition: "",
+      expectedStatus: 1,
+    },
+    {
+      name: "success result with scan-limit marker",
+      files: {
+        "validation-report.md": "validation\n",
+        "security-baseline-report.md": `${securityBaselineErrorMarker}\nscan limit\n`,
+      },
+      result: "validated",
+      baseline: "passed",
+      disposition: "clear",
+      expectedStatus: 1,
+    },
+    ...["v1", "v3", "v99"].map((version) => ({
+      name: `scan-limit result with unsupported ${version} marker`,
+      files: {
+        "validation-report.md": "validation\n",
+        "security-baseline-report.md": `<!-- marketplace-security-baseline-error:${version} -->\nscan limit\n`,
+      },
+      result: "validated",
+      baseline: "scan-error",
+      disposition: "",
+      expectedStatus: 1,
+    })),
     {
       name: "missing baseline",
       files: { "validation-report.md": "validation\n" },
       result: "validated",
       baseline: "passed",
+      disposition: "clear",
       expectedStatus: 1,
     },
     {
@@ -411,6 +743,7 @@ test("submission report consumer rejects tampering, links, and unexpected files"
       },
       result: "needs-fixes",
       baseline: "",
+      disposition: "",
       expectedStatus: 1,
     },
   ];
@@ -426,6 +759,7 @@ test("submission report consumer rejects tampering, links, and unexpected files"
           RUNNER_TEMP: directory,
           VALIDATION_RESULT: item.result,
           BASELINE_RESULT: item.baseline,
+          BASELINE_DISPOSITION: item.disposition,
         },
       });
       assert.equal(execution.status, item.expectedStatus, `${item.name}: ${execution.stderr}`);
@@ -445,6 +779,7 @@ test("submission report consumer rejects tampering, links, and unexpected files"
         RUNNER_TEMP: tamperedDirectory,
         VALIDATION_RESULT: "needs-fixes",
         BASELINE_RESULT: "",
+        BASELINE_DISPOSITION: "",
       },
     });
     assert.notEqual(execution.status, 0);
@@ -463,6 +798,7 @@ test("submission report consumer rejects tampering, links, and unexpected files"
         RUNNER_TEMP: linkedDirectory,
         VALIDATION_RESULT: "needs-fixes",
         BASELINE_RESULT: "",
+        BASELINE_DISPOSITION: "",
       },
     });
     assert.notEqual(execution.status, 0);


### PR DESCRIPTION
## Summary

- reserve exit code `3` exclusively for deterministic security-baseline scan-limit failures
- publish the concrete checksummed scan-limit report while keeping canonical baseline output absent
- clear stale validation, approval, and security labels and leave verified publication blocked
- reject legacy, future, swapped, or otherwise inconsistent marker and artifact states

## Security invariants

- the 512 KiB per-file and 8 MiB aggregate scanner limits remain unchanged
- unknown, transient, and internal baseline failures remain hard workflow failures
- scan-limit reports use the exact current v4 error marker and never become `passed`, `review-required`, or canonical `needs-fixes` baseline evidence
- approval still requires current canonical evidence and an exact-commit freshness check

## Testing

- `npm test` (289/289)
- focused scan-limit, publication, hard-failure, and artifact-consumer tests (4/4)
- YAML parsing for both changed workflows
- `node --check` for changed JavaScript files
- `git diff --check`

Addresses #1862.
