### PR TITLE
Add Kids catalog filter

### DIFF
--- a/scripts/build-explorer-data.mjs
+++ b/scripts/build-explorer-data.mjs
@@ -7,6 +7,7 @@ import {
   assertGrowthContinuity,
   readCommittedExplorerData,
 } from "./explorer-growth-history.mjs";
+import { matchesKidsTaxonomy } from "../site/assets/js/taxonomy.js";
 
 const catalogUrl = process.env.MARKETPLACE_EXPLORER_CATALOG_PATH
   ? resolve(process.env.MARKETPLACE_EXPLORER_CATALOG_PATH)
@@ -56,9 +57,7 @@ function tokens(plugin) {
 
 function assignCluster(plugin) {
   const sourceTags = plugin.tags || [];
-  if (plugin.category === "Kids" || sourceTags.includes("kids") || sourceTags.includes("education")) {
-    return "kids";
-  }
+  if (matchesKidsTaxonomy(plugin)) return "kids";
   const normalizedTags = sourceTags.map((tag) => String(tag).toLowerCase());
   const text = normalizedText(plugin);
   const name = ` ${plugin.name.toLowerCase()} `;

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,14 +25,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260830-02";
+} from "./engagement.js?v=20260831-01";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -59,7 +59,8 @@ import {
   searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260830-02";
+} from "./search.js?v=20260831-01";
+import { catalogCategoryTotals, matchesKidsTaxonomy } from "./taxonomy.js?v=20260831-01";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([
@@ -599,6 +600,7 @@ function allCategoryLabel() {
 
 function matchesCatalogFilter(plugin, filter = state.category) {
   if (filter === "all") return true;
+  if (filter === "Kids") return matchesKidsTaxonomy(plugin);
   if (filter.startsWith("tag:")) return (plugin.tags || []).includes(filter.slice(4));
   return plugin.category === filter;
 }
@@ -1092,8 +1094,7 @@ function renderSortOptions() {
 
 function renderCategories() {
   const plugins = sourcePlugins();
-  const categoryTotals = new Map();
-  plugins.forEach((plugin) => categoryTotals.set(plugin.category, (categoryTotals.get(plugin.category) || 0) + 1));
+  const categoryTotals = catalogCategoryTotals(plugins);
   const categoryFilters = [...categoryTotals.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([value, total]) => ({ value, label: value, total }));

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/explore-search.js
+++ b/site/assets/js/explore-search.js
@@ -2,7 +2,7 @@ import {
   matchesDirectSearch,
   matchesDraftSearchTerm,
   parseSearchDraft,
-} from "./search.js?v=20260830-02";
+} from "./search.js?v=20260831-01";
 
 export function repositoryPublisher(repo) {
   try {

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -1,5 +1,5 @@
-import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260830-02";
-import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260830-02";
+import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260831-01";
+import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260831-01";
 import { inclusiveDayCount, inclusiveRangeStart } from "./growth-range.js?v=20260828-18";
 
 const number = new Intl.NumberFormat("en-US");

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260830-02";
+} from "./engagement.js?v=20260831-01";
 
 function safeGitHubWebUrl(value) {
   try {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260830-02";
+} from "./shared.js?v=20260831-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/taxonomy.js
+++ b/site/assets/js/taxonomy.js
@@ -1,0 +1,12 @@
+export function matchesKidsTaxonomy(plugin) {
+  const tags = Array.isArray(plugin?.tags) ? plugin.tags : [];
+  return plugin?.category === "Kids" || tags.includes("kids") || tags.includes("education");
+}
+
+export function catalogCategoryTotals(plugins) {
+  const totals = new Map();
+  plugins.forEach((plugin) => totals.set(plugin.category, (totals.get(plugin.category) || 0) + 1));
+  const kidsTotal = plugins.filter(matchesKidsTaxonomy).length;
+  if (kidsTotal) totals.set("Kids", kidsTotal);
+  return totals;
+}

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/develop.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -238,6 +238,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/explore.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/app.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -37,6 +37,6 @@
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260831-01"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260830-02"></script>
+    <script type="module" src="assets/js/publish.js?v=20260831-01"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -92,6 +92,10 @@ import {
   showCopiedState,
   writeClipboard,
 } from "../site/assets/js/shared.js";
+import {
+  catalogCategoryTotals,
+  matchesKidsTaxonomy,
+} from "../site/assets/js/taxonomy.js";
 
 function contrastRatio(first, second) {
   const luminance = (hex) => {
@@ -1138,6 +1142,40 @@ test("clipboard fallback reports the actual copy result", async () => {
   }), true);
 });
 
+test("Kids catalog filtering uses only the exact controlled taxonomy", () => {
+  for (const plugin of [
+    { category: "Kids", tags: ["games"] },
+    { category: "Other", tags: ["kids", "kids"] },
+    { category: "Productivity", tags: ["education"] },
+  ]) {
+    assert.equal(matchesKidsTaxonomy(plugin), true);
+  }
+  for (const plugin of [
+    undefined,
+    {},
+    { category: "Productivity" },
+    { category: "kids", tags: ["quickshell"] },
+    { category: "Kids ", tags: ["quickshell"] },
+    { category: "Productivity", tags: ["Kids", "EDUCATION"] },
+    { category: "Productivity", tags: "education", description: "Kids education reference" },
+    { category: "Productivity", tags: ["quickshell"], description: "Kids education reference" },
+  ]) {
+    assert.equal(matchesKidsTaxonomy(plugin), false);
+  }
+
+  const totals = catalogCategoryTotals([
+    { category: "Kids", tags: ["games"] },
+    { category: "Kids", tags: ["education"] },
+    { category: "Other", tags: ["education"] },
+    { category: "Productivity", tags: ["quickshell"] },
+  ]);
+  assert.equal([...totals.keys()].filter((category) => category === "Kids").length, 1);
+  assert.equal(totals.get("Kids"), 3);
+  assert.equal(totals.get("Other"), 1);
+  assert.equal(totals.get("Productivity"), 1);
+  assert.equal(catalogCategoryTotals([{ category: "Other", tags: [] }]).has("Kids"), false);
+});
+
 test("entry modules and their shared dependency use one cache key", async () => {
   const root = new URL("../", import.meta.url);
   const files = {
@@ -1153,6 +1191,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
     engagementJs: await readFile(new URL("site/assets/js/engagement.js", root), "utf8"),
     sharedJs: await readFile(new URL("site/assets/js/shared.js", root), "utf8"),
     searchJs: await readFile(new URL("site/assets/js/search.js", root), "utf8"),
+    taxonomyJs: await readFile(new URL("site/assets/js/taxonomy.js", root), "utf8"),
     pluginJs: await readFile(new URL("site/assets/js/plugin.js", root), "utf8"),
     publishJs: await readFile(new URL("site/assets/js/publish.js", root), "utf8"),
     developJs: await readFile(new URL("site/assets/js/develop.js", root), "utf8"),
@@ -1174,6 +1213,7 @@ test("entry modules and their shared dependency use one cache key", async () => 
     files.app.match(/shared\.js\?v=([^"']+)/)?.[1],
     files.app.match(/engagement\.js\?v=([^"']+)/)?.[1],
     files.app.match(/search\.js\?v=([^"']+)/)?.[1],
+    files.app.match(/taxonomy\.js\?v=([^"']+)/)?.[1],
     files.pluginJs.match(/shared\.js\?v=([^"']+)/)?.[1],
     files.pluginJs.match(/engagement\.js\?v=([^"']+)/)?.[1],
     files.publishJs.match(/shared\.js\?v=([^"']+)/)?.[1],
@@ -1183,9 +1223,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260830-02");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260830-02");
-  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260830-02");
+  assert.equal(keys[0], "20260831-01");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260831-01");
+  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260831-01");
   assert.equal(files.exploreJs.match(/growth-range\.js\?v=([^"']+)/)?.[1], "20260828-18");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
@@ -1514,6 +1554,10 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(files.app, /"Search plugins, tag:panel, text:bar, or @author…"/);
   assert.match(files.app, /function filteredPlugins\(\) \{[\s\S]*searchScopePlugins\(\)\.filter\(\(plugin\) => pluginMatchesActiveSearch\(plugin\)\)/);
   assert.match(files.app, /const taxonomyFilterTags = \["ai", "games", "security"\]/);
+  assert.match(files.app, /if \(filter === "Kids"\) return matchesKidsTaxonomy\(plugin\)/);
+  assert.match(files.app, /const categoryTotals = catalogCategoryTotals\(plugins\)/);
+  assert.match(files.taxonomyJs, /export function catalogCategoryTotals\(plugins\)/);
+  assert.doesNotMatch(files.app, /taxonomyFilterTags = \[[^\]]*"kids"/);
   assert.match(files.app, /value: `tag:\$\{tag\}`/);
   assert.match(files.app, /return labels\.length \? labels : \[category \|\| "System"\]/);
   assert.match(files.sharedJs, /function matchesVerificationStatus\(plugin, status\) \{[\s\S]*!plugin\?\.builtIn[\s\S]*plugin\?\.repositoryLayout !== "suite"[\s\S]*plugin\?\.verificationStatus === status/);

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -38,9 +38,10 @@ function workflowJobSource(workflow, name, nextName = "") {
 function createExplorerBuilderFixture(growth, plugins = []) {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "explorer-builder-history-"));
   fs.mkdirSync(path.join(directory, "scripts"));
-  fs.mkdirSync(path.join(directory, "site"));
+  fs.mkdirSync(path.join(directory, "site", "assets", "js"), { recursive: true });
   fs.copyFileSync(new URL("../scripts/build-explorer-data.mjs", import.meta.url), path.join(directory, "scripts", "build-explorer-data.mjs"));
   fs.copyFileSync(new URL("../scripts/explorer-growth-history.mjs", import.meta.url), path.join(directory, "scripts", "explorer-growth-history.mjs"));
+  fs.copyFileSync(new URL("../site/assets/js/taxonomy.js", import.meta.url), path.join(directory, "site", "assets", "js", "taxonomy.js"));
   fs.writeFileSync(path.join(directory, "site", "catalog.json"), JSON.stringify({
     generatedAt: "2026-08-28T10:00:00.000Z",
     plugins,


### PR DESCRIPTION
## Summary

- add one visible `Kids` catalog filter that matches category `Kids` or the exact tags `kids` and `education`
- share the exact taxonomy predicate with the Explorer builder to prevent catalog/graph drift
- deduplicate category totals and suppress the filter when no matching plugins exist
- preserve case-sensitive URL state and fall back to `all` for an unavailable or malformed Kids filter
- update the coupled static asset cache key

## Testing

- `npm test` (290/290)
- Explorer regeneration remained byte-identical
- Chromium matrix: dark and light themes at 320, 375, 760, 761, 800, 850, 879, 880, 1024, and 1440 px
- verified one Kids button, correct count, active ARIA state, exact four current matches, and no horizontal overflow
- verified `?category=Kids`, combined Kids plus search state, and lowercase `?category=kids` fallback
- verified synthetic category/tag deduplication and zero-match filter suppression
- no browser exceptions
- `node --check` and `git diff --check`
