### PR TITLE
Speed up plugin search with caching and debounced input

### DIFF
--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -25,14 +25,14 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260831-01";
+} from "./shared.js?v=20260906-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
   loadEngagementStats,
   recordPluginCopy,
   recordPluginHeart,
-} from "./engagement.js?v=20260831-01";
+} from "./engagement.js?v=20260906-01";
 import {
   appendSearchState,
   committedTermsFromDraft,
@@ -59,8 +59,8 @@ import {
   searchTermInputValue,
   searchTermKey,
   selectSearchCompletions,
-} from "./search.js?v=20260831-01";
-import { catalogCategoryTotals, matchesKidsTaxonomy } from "./taxonomy.js?v=20260831-01";
+} from "./search.js?v=20260906-01";
+import { catalogCategoryTotals, matchesKidsTaxonomy } from "./taxonomy.js?v=20260906-01";
 
 const pluginsPerPage = 9;
 const hiddenCardTags = new Set([
@@ -179,19 +179,32 @@ let viewScrollFrame = 0;
 let searchCompletions = [];
 let activeSuggestion = -1;
 let searchBlurTimer = 0;
+let searchInputTimer = 0;
+const searchInputDelay = 120;
+const publisherLoginCache = new Map();
+const pluginSearchContextCache = new WeakMap();
+let cachedDraftQuery = null;
+let cachedDraftTerms = [];
 
 function sourcePlugins() {
   return state.plugins.filter((plugin) => (plugin.sourceType || "community") === state.source);
 }
 
 function publisherLogin(plugin) {
+  const cacheKey = plugin?.repo || "";
+  if (publisherLoginCache.has(cacheKey)) return publisherLoginCache.get(cacheKey);
+  let login = "";
   try {
     const url = new URL(plugin.repo);
-    if (url.hostname.toLowerCase() !== "github.com") return "";
-    return url.pathname.split("/").filter(Boolean)[0] || "";
+    if (url.hostname.toLowerCase() === "github.com") {
+      login = url.pathname.split("/").filter(Boolean)[0] || "";
+    }
   } catch {
-    return "";
+    login = "";
   }
+  if (publisherLoginCache.size > 5000) publisherLoginCache.clear();
+  publisherLoginCache.set(cacheKey, login);
+  return login;
 }
 
 function pluginSearchText(plugin) {
@@ -210,17 +223,28 @@ function pluginSearchText(plugin) {
 }
 
 function pluginSearchContext(plugin) {
-  return {
+  const cached = pluginSearchContextCache.get(plugin);
+  if (cached) return cached;
+  const context = {
     publisher: publisherLogin(plugin),
     primaryText: [plugin.name, plugin.id, ...(plugin.tags || [])].join(" "),
     searchText: pluginSearchText(plugin),
   };
+  pluginSearchContextCache.set(plugin, context);
+  return context;
+}
+
+function cachedDraftSearchTerms(query) {
+  if (query === cachedDraftQuery) return cachedDraftTerms;
+  cachedDraftQuery = query;
+  cachedDraftTerms = parseSearchDraft(query);
+  return cachedDraftTerms;
 }
 
 function pluginMatchesActiveSearch(plugin) {
   const { publisher, primaryText, searchText } = pluginSearchContext(plugin);
   const hasTerms = state.terms.length > 0;
-  const draftTerms = parseSearchDraft(state.query);
+  const draftTerms = cachedDraftSearchTerms(state.query);
   if (!hasTerms && !draftTerms.length) return true;
   const matchContext = {
     publisher,
@@ -462,6 +486,7 @@ function updateSearchAffordances() {
 }
 
 function removeSearchTerm(index) {
+  cancelScheduledSearchInput();
   const [removed] = state.terms.splice(index, 1);
   const presentation = searchTermPresentation(removed);
   if (!presentation) return;
@@ -500,6 +525,7 @@ function renderSearchTerms() {
 }
 
 function commitSearchDraft(completion) {
+  cancelScheduledSearchInput();
   const draftedTerms = committedTermsFromDraft(search.value, completion);
   if (!draftedTerms.length) return false;
   const existing = new Set(state.terms.map(searchTermKey));
@@ -531,6 +557,7 @@ function commitSearchDraft(completion) {
 }
 
 function clearSearchTerms({ focus = true } = {}) {
+  cancelScheduledSearchInput();
   state.terms = [];
   state.query = "";
   search.value = "";
@@ -540,6 +567,22 @@ function clearSearchTerms({ focus = true } = {}) {
   render();
   if (focus) search.focus();
   searchSuggestionStatus.textContent = searchResultMessage("Cleared all search terms");
+}
+
+function cancelScheduledSearchInput() {
+  if (searchInputTimer) {
+    window.clearTimeout(searchInputTimer);
+    searchInputTimer = 0;
+  }
+}
+
+function scheduleSearchInput() {
+  cancelScheduledSearchInput();
+  searchInputTimer = window.setTimeout(() => {
+    searchInputTimer = 0;
+    if (document.activeElement === search) updateSearchSuggestions();
+    render();
+  }, searchInputDelay);
 }
 
 function updateSearchSuggestions() {
@@ -1412,16 +1455,19 @@ async function init() {
     state.query = search.value;
     state.page = 1;
     updateSearchAffordances();
-    updateSearchSuggestions();
-    render();
+    scheduleSearchInput();
   });
 
   search.addEventListener("keydown", (event) => {
     if (event.isComposing) return;
     if (handleSearchEscape(event, {
       hasSuggestions: !searchSuggestions.hidden,
-      closeSuggestions: closeSearchSuggestions,
+      closeSuggestions: () => {
+        cancelScheduledSearchInput();
+        closeSearchSuggestions();
+      },
       clearSearch: () => {
+        cancelScheduledSearchInput();
         search.value = "";
         state.query = "";
         state.page = 1;
@@ -1431,6 +1477,7 @@ async function init() {
       },
     })) return;
     if (event.key === "Tab") {
+      cancelScheduledSearchInput();
       closeSearchSuggestions();
       return;
     }

--- a/site/assets/js/develop.js
+++ b/site/assets/js/develop.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260831-01";
+} from "./shared.js?v=20260906-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/assets/js/explore-search.js
+++ b/site/assets/js/explore-search.js
@@ -2,7 +2,7 @@ import {
   matchesDirectSearch,
   matchesDraftSearchTerm,
   parseSearchDraft,
-} from "./search.js?v=20260831-01";
+} from "./search.js?v=20260906-01";
 
 export function repositoryPublisher(repo) {
   try {

--- a/site/assets/js/explore.js
+++ b/site/assets/js/explore.js
@@ -1,5 +1,5 @@
-import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260831-01";
-import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260831-01";
+import { accentColor, formatDate, setupThemeToggle } from "./shared.js?v=20260906-01";
+import { createExplorerSearchMatcher, repositoryPublisher } from "./explore-search.js?v=20260906-01";
 import { inclusiveDayCount, inclusiveRangeStart } from "./growth-range.js?v=20260828-18";
 
 const number = new Intl.NumberFormat("en-US");

--- a/site/assets/js/plugin.js
+++ b/site/assets/js/plugin.js
@@ -21,7 +21,7 @@ import {
   showToast,
   updateEngagementSummary,
   updatePluginHeart
-} from "./shared.js?v=20260831-01";
+} from "./shared.js?v=20260906-01";
 import {
   engagementApiBaseUrl,
   hasPluginHeart,
@@ -29,7 +29,7 @@ import {
   recordPluginCopy,
   recordPluginHeart,
   recordPluginView,
-} from "./engagement.js?v=20260831-01";
+} from "./engagement.js?v=20260906-01";
 
 function safeGitHubWebUrl(value) {
   try {

--- a/site/assets/js/publish.js
+++ b/site/assets/js/publish.js
@@ -2,7 +2,7 @@ import {
   setupCopyButtons,
   setupSectionNavigation,
   setupThemeToggle,
-} from "./shared.js?v=20260831-01";
+} from "./shared.js?v=20260906-01";
 
 setupThemeToggle();
 setupCopyButtons();

--- a/site/develop.html
+++ b/site/develop.html
@@ -513,6 +513,6 @@ SOFTWARE.</code></pre></div>
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview start">Start</a><a href="#contract" data-section-ids="contract entry-point validate run">Build</a><a href="#finished" data-section-ids="finished troubleshooting">Finish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/develop.js?v=20260831-01"></script>
+    <script type="module" src="assets/js/develop.js?v=20260906-01"></script>
   </body>
 </html>

--- a/site/explore.html
+++ b/site/explore.html
@@ -239,6 +239,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
 
-    <script type="module" src="assets/js/explore.js?v=20260905-01"></script>
+    <script type="module" src="assets/js/explore.js?v=20260906-01"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -185,6 +185,6 @@
       <a href="publish.html"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M4 12h16"/></svg>Publish</a>
     </nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/app.js?v=20260831-01"></script>
+    <script type="module" src="assets/js/app.js?v=20260906-01"></script>
   </body>
 </html>

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -37,6 +37,6 @@
     <dialog class="preview-lightbox" id="preview-lightbox" aria-label="Plugin preview"></dialog>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview">Plugin</a><a id="mobile-install-link" href="#install" data-section-ids="install verification security">Install</a><a href="publish.html">Publish</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Command copied</div>
-    <script type="module" src="assets/js/plugin.js?v=20260831-01"></script>
+    <script type="module" src="assets/js/plugin.js?v=20260906-01"></script>
   </body>
 </html>

--- a/site/publish.html
+++ b/site/publish.html
@@ -56,6 +56,6 @@
     </div>
     <nav class="mobile-bottom" aria-label="Mobile navigation"><a href="index.html">Browse</a><a class="active" href="#overview" data-section-ids="overview requirements">Guide</a><a href="#manifest">Manifest</a><a href="#submit">Submit</a></nav>
     <div class="toast" id="toast" role="status" aria-live="polite">Copied</div>
-    <script type="module" src="assets/js/publish.js?v=20260831-01"></script>
+    <script type="module" src="assets/js/publish.js?v=20260906-01"></script>
   </body>
 </html>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1224,9 +1224,9 @@ test("entry modules and their shared dependency use one cache key", async () => 
   ];
   assert.ok(keys.every(Boolean));
   assert.equal(new Set(keys).size, 1);
-  assert.equal(keys[0], "20260831-01");
-  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260905-01");
-  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260831-01");
+  assert.equal(keys[0], "20260906-01");
+  assert.equal(files.explore.match(/explore\.js\?v=([^"']+)/)?.[1], "20260906-01");
+  assert.equal(files.exploreJs.match(/explore-search\.js\?v=([^"']+)/)?.[1], "20260906-01");
   assert.equal(files.exploreJs.match(/growth-range\.js\?v=([^"']+)/)?.[1], "20260828-18");
   const styleKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);


### PR DESCRIPTION
Every keystroke ran completion matching (~3 catalog loops with URL parsing and string folds) plus filteredPlugins twice, a full grid rebuild, and a history update. With 2500+ plugins this made typing feel laggy.

Changes (site/assets/js/app.js):
- Memoize publisher login by repo and per-plugin search context (Map + WeakMap)
- Parse the search draft once per distinct query instead of once per plugin
- Debounce suggestions + grid render by 120ms; affordances stay instant, Enter/accept/remove/clear/Esc/Tab cancel the pending run, blur skips suggestion reopen but still renders

Cache busting: coupled JS ?v= bumped to 20260906-01 across pages, imports, and test expectations.

Verification:
- npm test: 319 pass, 0 fail
- git diff --check clean, node --check clean
- Manual check via npm run dev: typing feels significantly faster
- Bench (median per filter pass, 2538 plugins): bar 35.8ms to 12.9ms, dark mode 20.2ms to 7.3ms, @author ~7.9x, tag: ~7.2x, empty ~16x; debounce further cuts runs from per-keystroke to per-pause