### PR TITLE
Link Omarchy branding in marketplace footer

### DIFF
--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1177,6 +1177,11 @@ svg.social-glyph { display: block; width: 14px; height: 14px; flex: none; fill: 
   display: grid; align-items: center; justify-items: center; gap: 5px;
   color: var(--faint); font-size: 9px; text-align: center;
 }
+.footer-wordmark-link { display: block; border: 0; background: transparent; line-height: 0; }
+.footer-wordmark-link img {
+  display: block; width: 82px; height: 24px; image-rendering: pixelated;
+}
+.footer-wordmark-link:hover img { filter: brightness(1.15); }
 .footer-project-name {
   color: var(--text); font-weight: 600; letter-spacing: .09em; white-space: nowrap;
 }

--- a/site/develop.html
+++ b/site/develop.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Develop and test a custom Omarchy Quattro plugin locally.">
     <meta name="theme-color" content="#000000">
     <title>Develop a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260906-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/site/explore.html
+++ b/site/explore.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000">
     <title>Explore Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260906-02">
     <link rel="stylesheet" href="assets/css/explore.css?v=20260828-27">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
@@ -223,7 +223,9 @@
       <div class="footer-status">
         <a class="footer-status-link footer-maintainer" href="https://github.com/HANCORE-linux" target="_blank" rel="noreferrer">HANCORE <span aria-hidden="true">↗</span></a>
         <div class="footer-status-copy">
-          <span class="footer-project-name">OMARCHY PLUGIN MARKETPLACE</span>
+          <a class="footer-wordmark-link" href="https://omarchy.org/" target="_blank" rel="noreferrer" aria-label="Visit Omarchy">
+            <img src="assets/img/omarchy-wordmark.png" alt="" width="656" height="192">
+          </a>
         </div>
         <div class="footer-resource-links">
           <a class="footer-status-link" href="https://github.com/omacom/omarchy-plugin-marketplace/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT LICENSE <span aria-hidden="true">↗</span></a>

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <title>Browse Plugins | Omarchy Plugins</title>
     <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml">
-    <link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="stylesheet" href="assets/css/style.css?v=20260906-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body class="marketplace-page">
@@ -48,7 +48,7 @@
         <div class="market-hero-copy">
           <div class="page-eyebrow">Community registry</div>
           <h1>discover omarchy plugins</h1>
-          <p>Browse community-built plugins for <a href="https://github.com/omacom/omarchy/tree/quattro" target="_blank" rel="noreferrer">Omarchy Quattro</a>. Inspect the source, copy the command, and shape your shell around the way you work.</p>
+          <p>Browse community-built plugins for <a href="https://omarchy.org/" target="_blank" rel="noreferrer">Omarchy Quattro</a>. Inspect the source, copy the command, and shape your shell around the way you work.</p>
           <div class="market-hero-actions">
             <a class="button market-primary" href="#catalog">Browse plugins <span aria-hidden="true">→</span></a>
             <a class="button" href="develop.html">Develop a plugin <span aria-hidden="true">→</span></a>
@@ -165,7 +165,9 @@
           HANCORE <span aria-hidden="true">↗</span>
         </a>
         <div class="footer-status-copy">
-          <span class="footer-project-name">OMARCHY PLUGIN MARKETPLACE</span>
+          <a class="footer-wordmark-link" href="https://omarchy.org/" target="_blank" rel="noreferrer" aria-label="Visit Omarchy">
+            <img src="assets/img/omarchy-wordmark.png" alt="" width="656" height="192">
+          </a>
         </div>
         <div class="footer-resource-links">
           <a class="footer-status-link" href="https://github.com/omacom/omarchy-plugin-marketplace/blob/main/LICENSE" target="_blank" rel="noreferrer">

--- a/site/plugin.html
+++ b/site/plugin.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Omarchy community plugin details and installation instructions.">
     <meta name="theme-color" content="#000000">
     <title>Plugin Details | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260906-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/site/publish.html
+++ b/site/publish.html
@@ -5,7 +5,7 @@
     <meta name="description" content="Publish an Omarchy plugin to the community marketplace.">
     <meta name="theme-color" content="#000000">
     <title>Publish a Plugin | Omarchy Plugins</title>
-    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260820-21">
+    <link rel="icon" href="favicon.svg?v=20260728-9" type="image/svg+xml"><link rel="stylesheet" href="assets/css/style.css?v=20260906-02">
     <script>document.documentElement.dataset.theme = localStorage.getItem("omarchy-theme") || "dark";</script>
   </head>
   <body>

--- a/test/automation.test.js
+++ b/test/automation.test.js
@@ -1232,13 +1232,16 @@ test("entry modules and their shared dependency use one cache key", async () => 
     .map((html) => html.match(/style\.css\?v=([^"']+)/)?.[1]);
   assert.ok(styleKeys.every(Boolean));
   assert.equal(new Set(styleKeys).size, 1);
-  assert.equal(styleKeys[0], "20260820-21");
+  assert.equal(styleKeys[0], "20260906-02");
   const faviconKeys = [files.index, files.plugin, files.publish, files.develop, files.explore]
     .map((html) => html.match(/favicon\.svg\?v=([^"']+)/)?.[1]);
   assert.ok(faviconKeys.every(Boolean));
   assert.equal(new Set(faviconKeys).size, 1);
   assert.match(files.index, /<title>Browse Plugins \| Omarchy Plugins<\/title>/);
-  assert.match(files.index, /Browse community-built plugins for <a href="https:\/\/github\.com\/omacom\/omarchy\/tree\/quattro"[^>]*>Omarchy Quattro<\/a>/);
+  for (const page of [files.index, files.plugin, files.publish, files.develop, files.explore]) {
+    assert.doesNotMatch(page, /omarchy-brand-(?:action|logo)/);
+  }
+  assert.match(files.index, /Browse community-built plugins for <a href="https:\/\/omarchy\.org\/"[^>]*>Omarchy Quattro<\/a>/);
   assert.equal((files.index.match(/href="develop\.html"/g) || []).length, 2);
   assert.equal((files.index.match(/href="explore\.html"/g) || []).length, 2);
   assert.match(files.index, /class="market-hero-actions"[\s\S]*Browse plugins[\s\S]*href="develop\.html">Develop a plugin[\s\S]*Publish a plugin/);
@@ -1825,8 +1828,21 @@ test("entry modules and their shared dependency use one cache key", async () => 
   assert.match(styles, /\.plugin-author button \{[\s\S]*z-index: 3/);
   assert.match(styles, /\.plugin-author button \{[\s\S]*min-height: 24px/);
   assert.match(styles, /\.plugin-author button:hover, \.plugin-author button:focus-visible \{ color: var\(--accent\); \}/);
-  assert.match(files.index, /class="footer-status"/);
-  assert.match(files.index, /HANCORE[\s\S]*OMARCHY PLUGIN MARKETPLACE[\s\S]*GITHUB/);
+  assert.match(files.index, /Browse community-built plugins for <a href="https:\/\/omarchy\.org\/"[^>]*>Omarchy Quattro<\/a>/);
+  for (const page of [files.index, files.explore]) {
+    assert.match(page, /class="footer-status"/);
+    assert.match(page, /HANCORE[\s\S]*<a class="footer-wordmark-link" href="https:\/\/omarchy\.org\/"[^>]*aria-label="Visit Omarchy">[\s\S]*<img src="assets\/img\/omarchy-wordmark\.png" alt="" width="656" height="192">\s*<\/a>[\s\S]*GITHUB/);
+    assert.doesNotMatch(page, /omarchy-footer(?:-still)?\.svg/);
+    assert.equal((page.match(/<span>PLUGIN MARKETPLACE<\/span>/g) || []).length, 1);
+  }
+  assert.doesNotMatch(styles, /omarchy-brand-(?:action|logo)/);
+  assert.match(styles, /\.footer-wordmark-link \{ display: block; border: 0; background: transparent; line-height: 0; \}/);
+  assert.match(styles, /\.footer-wordmark-link img \{[\s\S]*width: 82px; height: 24px;[\s\S]*image-rendering: pixelated;/);
+  assert.match(styles, /\.footer-wordmark-link:hover img \{ filter: brightness\(1\.15\); \}/);
+  assert.doesNotMatch(styles, /\.footer-wordmark-link[^}]*padding|\.footer-wordmark-link:hover[^}]*background/);
+  assert.doesNotMatch(`${files.app}${files.exploreJs}${styles}`, /FooterWordmarkDecrypt|footer-wordmark-decrypt|is-decrypting/);
+  assert.match(styles, /\.footer-status::before \{[\s\S]*background: linear-gradient/);
+  assert.match(styles, /\.footer-status::after \{[\s\S]*background: var\(--accent\); content: "";/);
   assert.doesNotMatch(files.index, /Independent community project\. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\./);
   assert.doesNotMatch(files.explore, /Independent community project\. Not affiliated with, sponsored by, or endorsed by Omarchy or 37signals\./);
   assert.doesNotMatch(files.index, /footer-tech-canvas|footer-project-canvas/);


### PR DESCRIPTION
## Summary

- link “Omarchy Quattro” to `https://omarchy.org/`
- replace the center footer text on the Browse and Explore pages with the existing static Omarchy wordmark
- keep the original footer layout, transparent background, `82 × 24 px` rendered size, link target, and hover brightness
- bump the shared stylesheet cache key across all five pages
- update the UI assertions for the new static wordmark

No animation, canvas, additional logo, or new image asset is included.

## Verification

- `npm test` — 323/323 passed
- JavaScript syntax checks passed
- `git diff --check origin/main..HEAD`
- Chromium checks across mobile and desktop, Dark and Light themes
- independent review completed with no findings
