### PR TITLE
Append shell restart to install command for clonedFrom plugins

### DIFF
--- a/scripts/build-catalog.mjs
+++ b/scripts/build-catalog.mjs
@@ -1323,7 +1323,7 @@ function repositoryGitUrl(repo) {
   return repo.endsWith(".git") ? repo : `${repo}.git`;
 }
 
-export function communityInstall(source, manifestPath, overrides = {}) {
+export function communityInstall(source, manifestPath, overrides = {}, clonedFrom = "") {
   const installation = overrides.installation;
   if (installation !== undefined) {
     if (
@@ -1346,11 +1346,17 @@ export function communityInstall(source, manifestPath, overrides = {}) {
     };
   }
   if (manifestPath === "manifest.json") {
+    const swapsFirstPartyService = typeof clonedFrom === "string" && clonedFrom.trim() !== "";
     return {
       repositoryLayout: "root-plugin",
       installAvailable: true,
-      installCommand: `omarchy plugin add ${repositoryGitUrl(source.repo)} --enable`,
-      installNote: "Omarchy clones the current upstream repository, validates it locally, and only then installs and enables the plugin.",
+      installCommand: swapsFirstPartyService
+        ? `omarchy plugin add ${repositoryGitUrl(source.repo)} --enable && omarchy restart shell`
+        : `omarchy plugin add ${repositoryGitUrl(source.repo)} --enable`,
+      installNote: swapsFirstPartyService
+        ? `Omarchy clones the current upstream repository, validates it locally, and only then installs and enables the plugin. This replaces the built-in ${clonedFrom} service, so the shell needs a restart before the swap fully takes effect.`
+        : "Omarchy clones the current upstream repository, validates it locally, and only then installs and enables the plugin.",
+      ...(swapsFirstPartyService ? { clonedFrom } : {}),
     };
   }
   return {
@@ -1466,6 +1472,9 @@ export async function discoveredPlugins(source, context, preview) {
       overrides.addedAt || source.addedAt,
       `${context.repository.slug}/${manifest.id}`,
     );
+    const clonedFrom = manifest.omarchy && typeof manifest.omarchy === "object" && !Array.isArray(manifest.omarchy)
+      ? String(manifest.omarchy.clonedFrom || "")
+      : "";
     plugins.push({
       id: manifest.id,
       name: manifest.name,
@@ -1482,7 +1491,7 @@ export async function discoveredPlugins(source, context, preview) {
         addedAt,
         `${context.repository.slug}/${manifest.id}`,
       ),
-      ...communityInstall(source, manifestPath, overrides),
+      ...communityInstall(source, manifestPath, overrides, clonedFrom),
       category: categoryFor(kinds),
       tags: kinds.slice(0, 3).map((kind) => kind.toLowerCase()),
       license: manifest.license || "See repository",
@@ -1522,6 +1531,7 @@ export function failedSourcePlugins(source, previousPlugins, context, checkedAt,
           source,
           plugin.manifestPath || "manifest.json",
           source.plugins?.[plugin.id] || {},
+          plugin.clonedFrom || "",
         )
       : null;
     const next = {

--- a/scripts/plugin-verification.mjs
+++ b/scripts/plugin-verification.mjs
@@ -235,12 +235,17 @@ function catalogWithStandardInstallation(catalog, source, pluginId) {
   let changed = false;
   const plugins = catalog.plugins.map((plugin) => {
     if (plugin !== catalogPlugin) return plugin;
+    const clonedFrom = plugin.clonedFrom || "";
     const next = {
       ...plugin,
       repositoryLayout: "root-plugin",
       installAvailable: true,
-      installCommand: `omarchy plugin add ${repositoryUrl} --enable`,
-      installNote: standardInstallationNote,
+      installCommand: clonedFrom
+        ? `omarchy plugin add ${repositoryUrl} --enable && omarchy restart shell`
+        : `omarchy plugin add ${repositoryUrl} --enable`,
+      installNote: clonedFrom
+        ? `${standardInstallationNote} This replaces the built-in ${clonedFrom} service, so the shell needs a restart before the swap fully takes effect.`
+        : standardInstallationNote,
       status: "Available",
     };
     changed ||= JSON.stringify(next) !== JSON.stringify(plugin);

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -332,6 +332,39 @@ test("manual installation overrides are explicit and restricted to root plugins"
   );
 });
 
+test("root plugins that clone a first-party service ask for a shell restart", () => {
+  const source = { repo: "https://github.com/example/idle-swap" };
+  const plain = communityInstall(source, "manifest.json", {});
+  assert.equal(
+    plain.installCommand,
+    "omarchy plugin add https://github.com/example/idle-swap.git --enable",
+  );
+  assert.equal("clonedFrom" in plain, false);
+
+  const swapped = communityInstall(source, "manifest.json", {}, "omarchy.idle");
+  assert.equal(
+    swapped.installCommand,
+    "omarchy plugin add https://github.com/example/idle-swap.git --enable && omarchy restart shell",
+  );
+  assert.match(swapped.installNote, /replaces the built-in omarchy\.idle service/);
+  assert.match(swapped.installNote, /shell needs a restart/);
+  assert.equal(swapped.clonedFrom, "omarchy.idle");
+});
+
+test("a manual installation override is unaffected by clonedFrom", () => {
+  const source = { repo: "https://github.com/example/native-plugin" };
+  const note = "This plugin requires a matching native helper.";
+  assert.deepEqual(
+    communityInstall(source, "manifest.json", { installation: { mode: "manual", note } }, "omarchy.idle"),
+    {
+      repositoryLayout: "root-plugin",
+      installAvailable: false,
+      installCommand: "",
+      installNote: note,
+    },
+  );
+});
+
 test("built-in plugins are separated from installable community plugins", () => {
   const builtIns = catalog.plugins.filter((plugin) => plugin.builtIn);
   assert.ok(builtIns.length > 20);


### PR DESCRIPTION
## Summary

- Plugins that declare `omarchy.clonedFrom` in their manifest (e.g. [Drift](https://github.com/riccardolanza05/omarchy-ray-screensaver) cloning `omarchy.idle`, [Lock Screen Explorer](https://github.com/SirJul1337/omarchy-lock-explorer) cloning `omarchy.lock`) swap in for a stock first-party service on enable, but `omarchy-shell` keeps the old service instance loaded until the shell is restarted — until then, IPC calls against the new plugin answer incorrectly (e.g. `Function not found`).
- Every such plugin's own README already documents `omarchy restart shell` as a required second step after `omarchy plugin add ... --enable`. This PR generates that step into the catalog's `installCommand`/`installNote` instead of leaving it to be discovered only in each plugin's own docs, so the site's copy-paste install command is correct by itself.
- `communityInstall()` now accepts the manifest's `omarchy.clonedFrom` value and, when present, appends `&& omarchy restart shell` to the install command and explains why in the install note. The value is cached on the catalog entry (`clonedFrom`) so the unreachable-repository fallback path in `failedSourcePlugins()` can reuse it without a fresh manifest fetch, and the maintainer-approved "standard installation" promotion path (`catalogWithStandardInstallation`) honors it too.
- Plugins without `clonedFrom` are unaffected: same command, no new field on the catalog entry.

## Test plan

- [x] `npm install && npm test` — all 321 tests pass, including two new unit tests covering `communityInstall()` with and without `clonedFrom`, and confirming the manual-installation-override path is untouched.