### PR TITLE
Treat a bare "pip install" as a mention, not as package management

### DIFF
--- a/scripts/security-baseline-analysis.mjs
+++ b/scripts/security-baseline-analysis.mjs
@@ -1422,7 +1422,7 @@ export function detectElevatedCapabilities(files, submissionRepository = "") {
       if (
         /\bomarchy\s+pkg\s+(?:add|drop|remove|update)\b/i.test(text)
         || /\b(?:pacman|paru|yay|apt|apt-get|dnf|zypper|apk)\s+(?:-[A-Za-z]*[SRU]|install|remove|upgrade|add|del)\b/i.test(text)
-        || /(?:^|[\s/'"])(?:pip|pip3|pipx)["']?\s+install\b/i.test(text)
+        || /(?:^|[\s/'"])(?:pip|pip3|pipx)["']?\s+install\s+[-\w.\/]/i.test(text)
         || /\bpython[23]?(?:\.[0-9]+)?\s+-m\s+pip\s+install\b/i.test(text)
         || /\b(?:npm|pnpm|yarn|bun)\s+(?:install|add)\b/i.test(text)
         || /\bcargo\s+install\b/i.test(text)

--- a/test/security-baseline.test.js
+++ b/test/security-baseline.test.js
@@ -602,6 +602,42 @@ test("absolute system utilities are not remote execution sinks", () => {
   }
 });
 
+test("pip install with nothing after it is a mention, not package management", () => {
+  // A README saying the plugin needs no packages still says the words. The
+  // pattern matched them, and a submission whose sentence was "Standard library
+  // only: nothing to compile, nothing to pip install, no D-Bus bindings" was
+  // labelled as able to install software.
+  //
+  // Only the case with no operand at all is excluded. "pip install <anything>"
+  // is still package management wherever it appears, including inside a denial,
+  // which is the same treatment sudo gets above.
+  for (const prose of [
+    "Standard library only: nothing to compile, nothing to pip install, no D-Bus bindings.",
+    "No pip install.",
+    "There is nothing to pip install",
+  ]) {
+    assert.deepEqual(
+      detectElevatedCapabilities([file("README.md", prose)]).map((capability) => capability.id),
+      [],
+      prose,
+    );
+  }
+  for (const command of [
+    "pip install openwakeword",
+    "pip3 install --user example",
+    "pipx install example-tool",
+    "${VENV}/bin/pip install openwakeword",
+    "python3 -m pip install example",
+    "Do not run pip install here",
+  ]) {
+    assert.ok(
+      detectElevatedCapabilities([file("scripts/setup.sh", command)])
+        .some((capability) => capability.id === "package-manager"),
+      command,
+    );
+  }
+});
+
 test("package managers, privilege boundaries, installers, and services require review", () => {
   const files = [
     file("bin/wake-word-setup", `${"${VENV}"}/bin/pip install openwakeword`),


### PR DESCRIPTION
The pip pattern in `detectElevatedCapabilities` matches the words wherever they appear, including where a README says the plugin needs no packages at all.

My submission (#6506) has a compatibility line reading:

> Standard library only: nothing to compile, nothing to pip install, no D-Bus bindings.

That was labelled `package-manager`, "The plugin can install, upgrade, or remove software outside its own checkout", on the strength of a sentence saying it does not. The plugin is Python standard library only, with no compilation step, no daemon and no udev rule.

**The change.** Require at least one operand character after `install`:

```diff
-|| /(?:^|[\s/'"])(?:pip|pip3|pipx)["']?\s+install\b/i.test(text)
+|| /(?:^|[\s/'"])(?:pip|pip3|pipx)["']?\s+install\s+[-\w.\/]/i.test(text)
```

`pip install <anything>` still matches wherever it appears, including inside a denial such as "Do not run pip install here", which is the same treatment `sudo` gets in the test directly above this one. Only `pip install` with nothing after it is excluded, and no pip would run that.

The other package managers are untouched. I left `npm install` alone deliberately, since with no arguments it is a real command.

**Tested.** `node --test test/security-baseline.test.js` passes 40 of 40 with the new case added. `npm test` gives the same 8 failures before and after the change; those are unrelated to it and come from my sparse checkout missing the registry and site fixtures.

Happy to drop this if the current behaviour is intended and the 🟡 review label is the designed outcome for prose. The label is doing its job in the sense that a maintainer does look, but the finding pointed at a sentence rather than at anything the plugin does.